### PR TITLE
DevOps: Code Coverage

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,4 @@
 ^\.Rproj\.user$
 ^LICENSE\.md$
 ^\.pre-commit-config\.yaml$
+^codecov\.yml$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ License: MIT + file LICENSE
 Imports: 
     renv
 Suggests: 
+    covr,
     precommit
 Encoding: UTF-8
 LazyData: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,3 +1,4 @@
+covr
 HK
 hktrafficcollisions
 LazyData


### PR DESCRIPTION
# Summary
This branch implements best DevOps practice in setting-up code coverage. This is a measurement of how many lines of code are executed while automated tests are running. In this regard, it is a good metric for how much testing is being done and consequently, how much of your code is being checked for errors or failures.

More information is provided on [this StackOverflow post](https://stackoverflow.com/questions/195008/what-is-code-coverage-and-how-do-you-measure-it#:~:text=Code%20coverage%20is%20a%20measurement,tests%20against%20the%20instrumented%20product.).

It uses the [covr](https://github.com/r-lib/covr) package.

Typically, this is used alongside software testing.

# Changes
The changes made in this PR are:
1. `covr` package added to repo (via `DESCRIPTION`)
1. Code report has been pushed up to codecov.io

***

# Check
- [x] A report is generated [here](https://codecov.io/gh/Hong-Kong-Districts-Info/hktrafficcollisions/branch/devops%2Fcode-coverage)
- [x] Can generate a report by running locally `covr::report()`
     + You will probably need to install the following packages first: `install.packages(pkgs = c('covr', 'DT'), Ncpus = 1)`
     + **Tip:** You can set the `Ncpus` argument to the number of cores on your machine to speed up the installation of packages. I usually set `Ncpus = parallel::detectCores() - 1` so that I have one core left to do other stuff on my machine.

***

## Note
Currently are not testing any of our code, so we expect code coverage to be 0%.

This is usually employed alongside [testthat](https://github.com/r-lib/testthat).

This branch is rebased off devops/precommit so some of the file changes currently seen in this branch are not actually relevant. They will disappear when #3 gets merged into the main branch.
