### PR TITLE
Feature: Basic accident popup and map widgets

### DIFF
--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -23,6 +23,7 @@ library(plotly)
 ## interactive map
 library(sf)
 library(leaflet)
+library(leaflet.extras)
 
 
 # Data import -------------------------------------------------------------

--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -30,3 +30,5 @@ library(leaflet.extras)
 
 ## Take data from {hkdatasets}
 hk_accidents <- hkdatasets::hk_accidents
+hk_vehicles <- hkdatasets::hk_vehicles
+hk_casualties <- hkdatasets::hk_casualties

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -9,6 +9,16 @@ hk_accidents_valid_sf <- st_as_sf(x = hk_accidents_valid, coords = c("longitude"
 # TODO: investigate why
 hk_accidents_valid_sf$Date <- as.Date(hk_accidents_valid_sf$Date, format = "%Y-%m-%d")
 
+# Combine date and time together as a complete POSIXct class time column
+# Easier for formatting
+hk_accidents_valid_sf$Date_Time <- as.POSIXct(
+  strptime(
+    paste0(hk_accidents_valid_sf$Date, " ", hk_accidents_valid_sf$Time),
+    format = "%Y-%m-%d %H%M",
+    tz = "Asia/Hong_Kong"
+    )
+  )
+
 CARTODB_POSITRON_TILE_URL <- "https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png"
 
 output$main_map <- renderLeaflet({

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -61,6 +61,8 @@ filter_collision_data <- reactive({
 
   data_filtered = filter(data_filtered, Severity %in% input$severity_filter)
 
+  data_filtered = filter(data_filtered, include_pex %in% input$pedestrian_involved_filter)
+
   data_filtered
 })
 
@@ -96,6 +98,8 @@ observe({
     tags$b("Number of casualties: "), tags$br(), filter_collision_data()$No__of_Casualties_Injured, tags$br(),
     # Involved parties
     tags$b("Involved parties: "), tags$br(), "TODO", tags$br()
+    # Involve pedestrians?
+    tags$b("Pedestrians involved? "), tags$br(), filter_collision_data()$include_pex, tags$br(),
     )
 
   leafletProxy(mapId = "main_map", data = filter_collision_data()) %>%

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -65,6 +65,9 @@ observe({
     # Collision severity as title
     "<h3>", filter_collision_data()$Severity, " Collision</h3>",
 
+    # Accident serial number
+    tags$b("Serial number: "), tags$br(), filter_collision_data()$Serial_No_, tags$br(),
+
     # Accident date and time
     tags$b("Accident date: "), tags$br(), strftime(filter_collision_data()$Date_Time, "%d %b %Y %H:%M"), tags$br(),
     # Full address of collision location

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -24,7 +24,9 @@ CARTODB_POSITRON_TILE_URL <- "https://cartodb-basemaps-{s}.global.ssl.fastly.net
 output$main_map <- renderLeaflet({
   leaflet() %>%
     addTiles(urlTemplate = CARTODB_POSITRON_TILE_URL) %>%
-    setView(lng = 114.2, lat = 22.3, zoom = 12)
+    setView(lng = 114.2, lat = 22.3, zoom = 12) %>%
+    # Add geocoder map widget
+    addSearchOSM(options = searchOptions(hideMarkerOnCollapse = TRUE))
 })
 
 output$nrow_filtered <- reactive(nrow(filter_collision_data()))

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -63,6 +63,15 @@ filter_collision_data <- reactive({
 
   data_filtered = filter(data_filtered, include_pex %in% input$pedestrian_involved_filter)
 
+  # Get the serial numbers (in vector form) where vehicles involved includes users' selected vehicle class
+  serial_no_with_selected_vehicle_class = hk_vehicles %>%
+    filter(Vehicle_Class %in% input$vehicle_class_filter) %>%
+    # convert single column data frame to vector
+    pull(Serial_No_) %>%
+    # remove duplicated serial number if there are more than 1 vehicle class
+    unique()
+  data_filtered = filter(data_filtered, Serial_No_ %in% serial_no_with_selected_vehicle_class)
+
   data_filtered
 })
 
@@ -96,10 +105,10 @@ observe({
     tags$b("District: "), tags$br(), filter_collision_data()$District_Council_District, tags$br(),
     # Number of injuries
     tags$b("Number of casualties: "), tags$br(), filter_collision_data()$No__of_Casualties_Injured, tags$br(),
-    # Involved parties
-    tags$b("Involved parties: "), tags$br(), "TODO", tags$br()
     # Involve pedestrians?
     tags$b("Pedestrians involved? "), tags$br(), filter_collision_data()$include_pex, tags$br(),
+    # Involved vehicle class
+    tags$b("Involved vehicle classes: "), tags$br(), filter_collision_data()$vehicle_class_involved, tags$br()
     )
 
   leafletProxy(mapId = "main_map", data = filter_collision_data()) %>%

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -49,11 +49,10 @@ fill_palette <- colorFactor(palette = c("#230B4C", "#C03A51", "#F1701E"), domain
 
 observe({
   leafletProxy(mapId = "main_map", data = filter_collision_data()) %>%
-    # proportional symbols
     clearMarkers() %>%
     addCircleMarkers(
-      # sqrt for proportional **area** of circles
-      radius = ~ sqrt(No__of_Casualties_Injured) * 2.5,
+      # fixed point size symbol
+      radius = 2.5,
       color = "#FFFFFF", weight = 1, opacity = .75,
       fillColor = ~ fill_palette(Severity), fillOpacity = .75,
       popup = ~ paste("Accident date: ", Date, "<br>", "Number of casualties: ", No__of_Casualties_Injured))

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -58,14 +58,6 @@ output$main_map <- renderLeaflet({
     addLayersControl(baseGroups = names(basemap_providers),
                      options = layersControlOptions(collapsed = TRUE),
                      position = "topleft") %>%
-    htmlwidgets::onRender("
-    function(el, x) {
-      var myMap = this;
-      myMap.on('baselayerchange',
-        function (e) {
-          myMap.minimap.changeLayer(L.tileLayer.provider(e.name));
-        })
-    }")
 })
 
 output$nrow_filtered <- reactive(nrow(filter_collision_data()))

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -47,7 +47,34 @@ filter_collision_data <- reactive({
 # Fill color palette according to the severity of the accident
 fill_palette <- colorFactor(palette = c("#230B4C", "#C03A51", "#F1701E"), domain = c("Fatal", "Serious", "Slight"))
 
+
 observe({
+  # Template for popup, with summary of incidents
+  popup_template = paste(
+
+    # Control size of popups
+    # https://stackoverflow.com/questions/29365749/how-to-control-popups-width-for-leaflet-features-popup-in-r
+    "<style> div.leaflet-popup-content {width:200px !important;}</style>",
+
+    # Square symbol indicating severity level
+    # Use raw htmls since adding reactive expressions into tags$ will result in error
+    "<div style=\"height:20px; width:20px; float:left; margin-right:10px; background-color:", fill_palette(filter_collision_data()$Severity) ,"\";>", "</div>",
+
+    # Collision severity as title
+    "<h3>", filter_collision_data()$Severity, " Collision</h3>",
+
+    # Accident date and time
+    tags$b("Accident date: "), tags$br(), strftime(filter_collision_data()$Date_Time, "%d %b %Y %H:%M"), tags$br(),
+    # Full address of collision location
+    tags$b("Precise location: "), tags$br(), "TODO", tags$br(),
+    # District
+    tags$b("District: "), tags$br(), filter_collision_data()$District_Council_District, tags$br(),
+    # Number of injuries
+    tags$b("Number of casualties: "), tags$br(), filter_collision_data()$No__of_Casualties_Injured, tags$br(),
+    # Involved parties
+    tags$b("Involved parties: "), tags$br(), "TODO", tags$br()
+    )
+
   leafletProxy(mapId = "main_map", data = filter_collision_data()) %>%
     clearMarkers() %>%
     addCircleMarkers(
@@ -55,5 +82,6 @@ observe({
       radius = 2.5,
       color = "#FFFFFF", weight = 1, opacity = .75,
       fillColor = ~ fill_palette(Severity), fillOpacity = .75,
-      popup = ~ paste("Accident date: ", Date, "<br>", "Number of casualties: ", No__of_Casualties_Injured))
+      popup = popup_template
+      )
 })

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -54,10 +54,12 @@ output$main_map <- renderLeaflet({
   }
 
   # Add change basemap widget
-  overview_map %>%
-    addLayersControl(baseGroups = names(basemap_providers),
-                     options = layersControlOptions(collapsed = TRUE),
-                     position = "topleft") %>%
+  addLayersControl(
+    overview_map,
+    baseGroups = names(SELECTED_BASEMAPS),
+    options = layersControlOptions(collapsed = TRUE),
+    position = "topleft"
+    )
 })
 
 output$nrow_filtered <- reactive(nrow(filter_collision_data()))

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -158,6 +158,26 @@ ui <- dashboardPage(
               ),
 
               pickerInput(
+                inputId = "vehicle_class_filter", label = "Vehicle classes involved in the collision",
+                choices = unique(hk_vehicles$Vehicle_Class),
+                selected = unique(hk_vehicles$Vehicle_Class),
+                multiple = TRUE,
+                options = list(
+                  `actions-box` = TRUE,
+                  `deselect-all-text` = "Unselect All",
+                  `select-all-text` = "Select All",
+                  `none-selected-text` = "Select vehicle class(es)...",
+                  `selected-text-format` = "count",
+                  `count-selected-text` = "{0} vehicle classes choosed (on a total of {1})"
+                ),
+                choicesOpt = NULL,
+                width = NULL,
+                inline = FALSE
+              ),
+
+              p("NOTE: Multiple selections mean the accident includes ANY of the selected classes (instead of includes ALL of the selected classes)."),
+
+              pickerInput(
                 inputId = "severity_filter", label = "Accident Severity",
                 choices = unique(hk_accidents$Severity),
                 selected = unique(hk_accidents$Severity),

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -173,8 +173,16 @@ ui <- dashboardPage(
                 choicesOpt = NULL,
                 width = NULL,
                 inline = FALSE
-              )
+              ),
 
+              # Multiple UI choices available for this filter
+              # TODO: select between `checkboxGroupInput` or `checkboxGroupButtons` as UI of this filter
+              checkboxGroupButtons(
+                inputId = "pedestrian_involved_filter", label = "Pedestrian Involved in the accident?",
+                choices = list("Yes" = TRUE, "No" = FALSE),
+                selected = list(TRUE, FALSE),
+                justified = TRUE, status = "primary"
+              )
             )
           )
         ),

--- a/renv.lock
+++ b/renv.lock
@@ -338,6 +338,13 @@
       "Repository": "CRAN",
       "Hash": "e3d73becdeb92754d27172d278cbf61d"
     },
+    "leaflet.extras": {
+      "Package": "leaflet.extras",
+      "Version": "1.0.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "8dbfc2c4d7ca2660971caf1153ca95c2"
+    },
     "leaflet.providers": {
       "Package": "leaflet.providers",
       "Version": "1.9.0",
@@ -533,6 +540,20 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "dfd843ee98246cf932823acf613b05dd"
+    },
+    "stringi": {
+      "Package": "stringi",
+      "Version": "1.5.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a063ebea753c92910a4cca7b18bc1f05"
+    },
+    "stringr": {
+      "Package": "stringr",
+      "Version": "1.4.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "0759e6b6c0957edb1311028a49a35e76"
     },
     "sys": {
       "Package": "sys",

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.0.2",
+    "Version": "4.1.0",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -18,24 +18,24 @@
     },
     "KernSmooth": {
       "Package": "KernSmooth",
-      "Version": "2.23-17",
+      "Version": "2.23-20",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "bbff70c8c0357b5b88238c83f680fcd3"
+      "Hash": "8dcfa99b14c296bc9f1fd64d52fd3ce7"
     },
     "MASS": {
       "Package": "MASS",
-      "Version": "7.3-51.6",
+      "Version": "7.3-54",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "1dad32ac9dbd8057167b2979fb932ff7"
+      "Hash": "0e59129db205112e3963904db67fd0dc"
     },
     "Matrix": {
       "Package": "Matrix",
-      "Version": "1.2-18",
+      "Version": "1.3-3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "08588806cba69f04797dab50627428ed"
+      "Hash": "df57c82e79600601287edfdcef92c2d6"
     },
     "R6": {
       "Package": "R6",
@@ -74,24 +74,24 @@
     },
     "bslib": {
       "Package": "bslib",
-      "Version": "0.2.4",
+      "Version": "0.2.5.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "4830a372b241d78ed6f53731ee3023ac"
+      "Hash": "2f069f3f42847231aef7baa49bed97b0"
     },
     "cachem": {
       "Package": "cachem",
-      "Version": "1.0.4",
+      "Version": "1.0.5",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "2703a46dcabfb902f10060b2bca9f708"
+      "Hash": "5346f76a33eb7417812c270b04a5581b"
     },
     "class": {
       "Package": "class",
-      "Version": "7.3-17",
+      "Version": "7.3-19",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "9267f5dab59a4ef44229858a142bded1"
+      "Hash": "1593b7beb067c8381c0d24e38bd778e0"
     },
     "classInt": {
       "Package": "classInt",
@@ -172,10 +172,10 @@
     },
     "e1071": {
       "Package": "e1071",
-      "Version": "1.7-6",
+      "Version": "1.7-7",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "9a374a10e3c0dbf1a0e207af019bfcea"
+      "Hash": "7426a46e210d9f3815ed793e7112f582"
     },
     "ellipsis": {
       "Package": "ellipsis",
@@ -186,10 +186,10 @@
     },
     "fansi": {
       "Package": "fansi",
-      "Version": "0.4.2",
+      "Version": "0.5.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "fea074fb67fe4c25d47ad09087da847d"
+      "Hash": "d447b40982c576a72b779f0a3b3da227"
     },
     "farver": {
       "Package": "farver",
@@ -221,10 +221,10 @@
     },
     "ggplot2": {
       "Package": "ggplot2",
-      "Version": "3.3.3",
+      "Version": "3.3.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "3eb6477d01eb5bbdc03f7d5f70f2733e"
+      "Hash": "53ed0e82132d7f6ade8428f494d175e1"
     },
     "glue": {
       "Package": "glue",
@@ -319,10 +319,10 @@
     },
     "lattice": {
       "Package": "lattice",
-      "Version": "0.20-41",
+      "Version": "0.20-44",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "fbd9285028b0263d76d18c95ae51a53d"
+      "Hash": "f36bf1a849d9106dc2af72e501f9de41"
     },
     "lazyeval": {
       "Package": "lazyeval",
@@ -375,10 +375,10 @@
     },
     "mgcv": {
       "Package": "mgcv",
-      "Version": "1.8-31",
+      "Version": "1.8-35",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "4bb7e0c4f3557583e1e8d3c9ffb8ba5c"
+      "Hash": "89fd8b2ad4a6cb4979b78cf2a77ab503"
     },
     "mime": {
       "Package": "mime",
@@ -396,10 +396,10 @@
     },
     "nlme": {
       "Package": "nlme",
-      "Version": "3.1-148",
+      "Version": "3.1-152",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "662f52871983ff3e3ef042c62de126df"
+      "Hash": "35de1ce639f20b5e10f7f46260730c65"
     },
     "openssl": {
       "Package": "openssl",
@@ -410,10 +410,10 @@
     },
     "pillar": {
       "Package": "pillar",
-      "Version": "1.6.0",
+      "Version": "1.6.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "a8c755912ae31910ba6a5d42f5526b6b"
+      "Hash": "8672ae02bd20f6479bce2d06c7ff1401"
     },
     "pkgconfig": {
       "Package": "pkgconfig",
@@ -424,10 +424,10 @@
     },
     "plotly": {
       "Package": "plotly",
-      "Version": "4.9.3",
+      "Version": "4.9.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "f6b85d9e4ed88074ea0ede1aa74bb00e"
+      "Hash": "3f385f2cd5c270ea3bbe68cb94f7c558"
     },
     "png": {
       "Package": "png",
@@ -445,10 +445,10 @@
     },
     "proxy": {
       "Package": "proxy",
-      "Version": "0.4-25",
+      "Version": "0.4-26",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "29a4dd5b440af584aed8c448d8eefb6e"
+      "Hash": "50b405c6419e921b9e9360cc9ebbcf2d"
     },
     "purrr": {
       "Package": "purrr",
@@ -485,12 +485,19 @@
       "Repository": "CRAN",
       "Hash": "515f341d3affe0de9e4a7f762efb0456"
     },
-    "sass": {
-      "Package": "sass",
-      "Version": "0.3.1",
+    "s2": {
+      "Package": "s2",
+      "Version": "1.0.5",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "3ef1adfe46b7b144b970d74ce33ab0d6"
+      "Hash": "02f7d4821a7ca841bbfdf3b7176ce6cf"
+    },
+    "sass": {
+      "Package": "sass",
+      "Version": "0.4.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "50cf822feb64bb3977bda0b7091be623"
     },
     "scales": {
       "Package": "scales",
@@ -501,10 +508,10 @@
     },
     "sf": {
       "Package": "sf",
-      "Version": "0.9-8",
+      "Version": "1.0-0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "d82215b501772c9faadb4dcd71395c7d"
+      "Hash": "800804f284ba87cb28cf24fc47fc4e02"
     },
     "shiny": {
       "Package": "shiny",
@@ -543,10 +550,10 @@
     },
     "stringi": {
       "Package": "stringi",
-      "Version": "1.5.3",
+      "Version": "1.6.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "a063ebea753c92910a4cca7b18bc1f05"
+      "Hash": "9df5e6f9a7fa11b84adf0429961de66a"
     },
     "stringr": {
       "Package": "stringr",
@@ -564,10 +571,10 @@
     },
     "tibble": {
       "Package": "tibble",
-      "Version": "3.1.1",
+      "Version": "3.1.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "fbbca141541ee9242233ba50b0fcb843"
+      "Hash": "349b40a9f144516d537c875e786ec8b8"
     },
     "tidyr": {
       "Package": "tidyr",
@@ -585,10 +592,10 @@
     },
     "units": {
       "Package": "units",
-      "Version": "0.7-1",
+      "Version": "0.7-2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "1eb71bc3895bf5a047485c16758c4862"
+      "Hash": "e0f85712d5371ab2841f63cdb33fe0f0"
     },
     "utf8": {
       "Package": "utf8",
@@ -606,10 +613,10 @@
     },
     "viridis": {
       "Package": "viridis",
-      "Version": "0.6.0",
+      "Version": "0.6.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "fc8caaf9fddeaa87fb7d0ee1890a3bc2"
+      "Hash": "424d1285b7372d39806abb19467e4df4"
     },
     "viridisLite": {
       "Package": "viridisLite",
@@ -625,12 +632,19 @@
       "Repository": "CRAN",
       "Hash": "ad03909b44677f930fa156d47d7a3aeb"
     },
-    "xfun": {
-      "Package": "xfun",
-      "Version": "0.22",
+    "wk": {
+      "Package": "wk",
+      "Version": "0.4.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "eab2f8ba53809c321813e72ecbbd19ba"
+      "Hash": "f7e41a60d8b19cf505ffa06bf578c7bd"
+    },
+    "xfun": {
+      "Package": "xfun",
+      "Version": "0.24",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "88cdb9779a657ad80ad942245fffba31"
     },
     "xtable": {
       "Package": "xtable",


### PR DESCRIPTION
# Summary
This branch adds two map widgets for the collision location map and creates a basic popup template.

# Changes
The changes made in this PR are:
1. Add a geocoding map widget
    <img width="751" alt="geocoder-widget" src="https://user-images.githubusercontent.com/29334677/121246670-ffc9c500-c8d3-11eb-9e5b-6f12325c1c1d.png">

2. Add a change basemap map widget
    <img width="577" alt="change-basemap-widget" src="https://user-images.githubusercontent.com/29334677/121246694-048e7900-c8d4-11eb-8ab0-e4d004cb3f6c.png">

3. Create a popup template to show the summary of the accidents when users click on the points
    <img width="669" alt="popup-template" src="https://user-images.githubusercontent.com/29334677/121246718-08ba9680-c8d4-11eb-8a76-5dacb2bb0be0.png">


***

# Check
- [x] The travis.ci and R CMD checks pass.

***

## Note

- The list of basemap tile providers included is subject to change (we may have a deeper discussion on this). In this PR I included 3 common basemap tiles as the skeleton code for easier future developments.
- The details of the popup is subject to the next release of **hkdatasets**.

