### PR TITLE
Feature: Show/Hide filter button

### DIFF
--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -122,89 +122,98 @@ ui <- dashboardPage(
 
               h2("Filter Panel"),
 
-              p("Number of rows: ", textOutput("nrow_filtered", inline = TRUE)),
+              # Add collapse button from bootstrap
+              # https://stackoverflow.com/a/53148626/14131305
+              HTML('<button id="collapse-button" data-toggle="collapse" data-target="#filter-panel">Hide/Show Filters</button>'),
 
-              dateRangeInput(
-                inputId = "date_filter", label = "Date range:",
-                start = "2016-05-01",
-                end   = "2016-06-30",
-                format = "d MM yyyy"
-              ),
+              # filters
+              tags$div(
+                id = 'filter-panel', class = "collapse in",
 
-              checkboxGroupButtons(
-                inputId = "severity_filter", label = "Accident Severity",
-                choices = c(`Fatal <i style="color:#230B4C;" class="fas fa-skull-crossbones"></i>` = "Fatal",
-                            `Serious <i style="color:#C03A51;"class="fas fa-procedures"></i>` = "Serious",
-                            `Slight <i style="color:#F1701E;" class="fas fa-user-injured"></i>` = "Slight"),
-                selected = unique(hk_accidents$Severity),
-                direction = "vertical",
-                justified = TRUE,
-                checkIcon = list(yes = icon("ok", lib = "glyphicon"))
-              ),
+                p("Number of rows: ", textOutput("nrow_filtered", inline = TRUE)),
 
-              pickerInput(
-                inputId = "collision_type_filter", label = "Collision Type",
-                choices = unique(hk_accidents$Type_of_Collision),
-                selected = unique(hk_accidents$Type_of_Collision),
-                multiple = TRUE,
-                options = list(
-                  `actions-box` = TRUE,
-                  `deselect-all-text` = "Unselect All",
-                  `select-all-text` = "Select All",
-                  `none-selected-text` = "Select collision type(s)...",
-                  `selected-text-format` = "count",
-                  `count-selected-text` = "{0} collision types chosen (on a total of {1})"
+                dateRangeInput(
+                  inputId = "date_filter", label = "Date range:",
+                  start = "2016-05-01",
+                  end   = "2016-06-30",
+                  format = "d MM yyyy"
                 ),
-                choicesOpt = NULL,
-                width = NULL,
-                inline = FALSE
-              ),
 
-              pickerInput(
-                inputId = "casualty_filter", label = "Casualty Role",
-                choices = unique(hk_casualties$Role_of_Casualty),
-                selected = unique(hk_casualties$Role_of_Casualty),
-                multiple = TRUE,
-                options = list(
-                  `actions-box` = TRUE,
-                  `deselect-all-text` = "Unselect All",
-                  `select-all-text` = "Select All",
-                  `none-selected-text` = "Select casualty role(s)...",
-                  `selected-text-format` = "count",
-                  `count-selected-text` = "{0} casualty roles chosen (on a total of {1})"
+                checkboxGroupButtons(
+                  inputId = "severity_filter", label = "Accident Severity",
+                  choices = c(`Fatal <i style="color:#230B4C;" class="fas fa-skull-crossbones"></i>` = "Fatal",
+                              `Serious <i style="color:#C03A51;"class="fas fa-procedures"></i>` = "Serious",
+                              `Slight <i style="color:#F1701E;" class="fas fa-user-injured"></i>` = "Slight"),
+                  selected = unique(hk_accidents$Severity),
+                  direction = "vertical",
+                  justified = TRUE,
+                  checkIcon = list(yes = icon("ok", lib = "glyphicon"))
                 ),
-                choicesOpt = NULL,
-                width = NULL,
-                inline = FALSE
-              ),
 
-              pickerInput(
-                inputId = "vehicle_class_filter", label = "Vehicle classes involved in the collision",
-                choices = unique(hk_vehicles$Vehicle_Class),
-                selected = unique(hk_vehicles$Vehicle_Class),
-                multiple = TRUE,
-                options = list(
-                  `actions-box` = TRUE,
-                  `deselect-all-text` = "Unselect All",
-                  `select-all-text` = "Select All",
-                  `none-selected-text` = "Select vehicle class(es)...",
-                  `selected-text-format` = "count",
-                  `count-selected-text` = "{0} vehicle classes chosen (on a total of {1})"
+                pickerInput(
+                  inputId = "collision_type_filter", label = "Collision Type",
+                  choices = unique(hk_accidents$Type_of_Collision),
+                  selected = unique(hk_accidents$Type_of_Collision),
+                  multiple = TRUE,
+                  options = list(
+                    `actions-box` = TRUE,
+                    `deselect-all-text` = "Unselect All",
+                    `select-all-text` = "Select All",
+                    `none-selected-text` = "Select collision type(s)...",
+                    `selected-text-format` = "count",
+                    `count-selected-text` = "{0} collision types chosen (on a total of {1})"
+                  ),
+                  choicesOpt = NULL,
+                  width = NULL,
+                  inline = FALSE
                 ),
-                choicesOpt = NULL,
-                width = NULL,
-                inline = FALSE
-              ),
 
-              p("NOTE: Multiple selections means filtering accidents including ANY selected classes
-                (instead of ALL selected classes)."),
+                pickerInput(
+                  inputId = "casualty_filter", label = "Casualty Role",
+                  choices = unique(hk_casualties$Role_of_Casualty),
+                  selected = unique(hk_casualties$Role_of_Casualty),
+                  multiple = TRUE,
+                  options = list(
+                    `actions-box` = TRUE,
+                    `deselect-all-text` = "Unselect All",
+                    `select-all-text` = "Select All",
+                    `none-selected-text` = "Select casualty role(s)...",
+                    `selected-text-format` = "count",
+                    `count-selected-text` = "{0} casualty roles chosen (on a total of {1})"
+                  ),
+                  choicesOpt = NULL,
+                  width = NULL,
+                  inline = FALSE
+                ),
 
-              sliderInput(
-                inputId = "n_causality_filter", label = "No. of casualties",
-                min = min(hk_accidents$No__of_Casualties_Injured),
-                max = max(hk_accidents$No__of_Casualties_Injured),
-                value = range(hk_accidents$No__of_Casualties_Injured),
-                step = 1
+                pickerInput(
+                  inputId = "vehicle_class_filter", label = "Vehicle classes involved in the collision",
+                  choices = unique(hk_vehicles$Vehicle_Class),
+                  selected = unique(hk_vehicles$Vehicle_Class),
+                  multiple = TRUE,
+                  options = list(
+                    `actions-box` = TRUE,
+                    `deselect-all-text` = "Unselect All",
+                    `select-all-text` = "Select All",
+                    `none-selected-text` = "Select vehicle class(es)...",
+                    `selected-text-format` = "count",
+                    `count-selected-text` = "{0} vehicle classes chosen (on a total of {1})"
+                  ),
+                  choicesOpt = NULL,
+                  width = NULL,
+                  inline = FALSE
+                ),
+
+                p("NOTE: Multiple selections means filtering accidents including ANY selected classes
+                  (instead of ALL selected classes)."),
+
+                sliderInput(
+                  inputId = "n_causality_filter", label = "No. of casualties",
+                  min = min(hk_accidents$No__of_Casualties_Injured),
+                  max = max(hk_accidents$No__of_Casualties_Injured),
+                  value = range(hk_accidents$No__of_Casualties_Injured),
+                  step = 1
+                )
               )
             )
           )

--- a/inst/app/www/styles.css
+++ b/inst/app/www/styles.css
@@ -15,3 +15,8 @@
   opacity: 0.95;
   transition-delay: 0;
 }
+
+#collapse-button {
+  margin: 10px auto !important;
+  display: flex !important;
+}


### PR DESCRIPTION
# Summary
This branch adds a button in the filter panel to show/hide the filters, as discussed in https://github.com/Hong-Kong-Districts-Info/hktrafficcollisions/pull/14#issuecomment-888261748.

# Changes
The changes made in this PR are:
1. A button on top of the filter panel to show/hide filters below when clicked.

    https://user-images.githubusercontent.com/29334677/129491477-151f214b-91f6-44cc-845f-965a9542f8f9.mp4

***

# Check
- [x] The travis.ci and R CMD checks pass.

***

## Note
The style of the button is the default one from bootstrap. It is possible to apply additional CSS to match the theme of the dashboard.