### PR TITLE
Chore: Bump **hkdatasets**

### DIFF
--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -29,6 +29,6 @@ library(leaflet.extras)
 # Data import -------------------------------------------------------------
 
 ## Take data from {hkdatasets}
-hk_accidents <- hkdatasets::hk_accidents
+hk_accidents <- hkdatasets:::hk_accidents
 hk_vehicles <- hkdatasets::hk_vehicles
 hk_casualties <- hkdatasets::hk_casualties

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -24,21 +24,6 @@ hk_accidents_valid <- filter(hk_accidents_join, !is.na(latitude) & !is.na(longit
 # https://rstudio.github.io/leaflet/projections.html
 hk_accidents_valid_sf <- st_as_sf(x = hk_accidents_valid, coords = c("longitude", "latitude"), crs = 4326, remove = FALSE)
 
-# Need to convert to POSIXct again, otherwise reactive filtering does not work
-# TODO: investigate why
-hk_accidents_valid_sf$Date <- as.Date(hk_accidents_valid_sf$Date, format = "%Y-%m-%d")
-
-# Combine date and time together as a complete POSIXct class time column
-# Easier for formatting
-hk_accidents_valid_sf$Date_Time <- as.POSIXct(
-  strptime(
-    paste0(hk_accidents_valid_sf$Date, " ", hk_accidents_valid_sf$Time),
-    format = "%Y-%m-%d %H%M",
-    tz = "Asia/Hong_Kong"
-    )
-  )
-
-
 output$main_map <- renderLeaflet({
   overview_map <- leaflet() %>%
     setView(lng = 114.2, lat = 22.3, zoom = 12) %>%

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -53,7 +53,7 @@ output$nrow_filtered <- reactive(nrow(filter_collision_data()))
 # Filter the collision data according to users' input
 filter_collision_data <- reactive({
 
-  data_filtered = filter(hk_accidents_valid_sf, Date >= input$date_filter[1] & Date <= input$date_filter[2])
+  data_filtered = filter(hk_accidents_valid_sf, as.Date(Date_Time) >= input$date_filter[1] & as.Date(Date_Time) <= input$date_filter[2])
 
   data_filtered = filter(data_filtered,
                                 No_of_Casualties_Injured >= input$n_causality_filter[1] & No_of_Casualties_Injured <= input$n_causality_filter[2])

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -71,7 +71,7 @@ filter_collision_data <- reactive({
   data_filtered = filter(hk_accidents_valid_sf, Date >= input$date_filter[1] & Date <= input$date_filter[2])
 
   data_filtered = filter(data_filtered,
-                                No__of_Casualties_Injured >= input$n_causality_filter[1] & No__of_Casualties_Injured <= input$n_causality_filter[2])
+                                No_of_Casualties_Injured >= input$n_causality_filter[1] & No_of_Casualties_Injured <= input$n_causality_filter[2])
 
   data_filtered = filter(data_filtered, Type_of_Collision %in% input$collision_type_filter)
 
@@ -124,7 +124,7 @@ observe({
     # District
     tags$b("District: "), tags$br(), filter_collision_data()$District_Council_District, tags$br(),
     # Number of injuries
-    tags$b("Number of casualties: "), tags$br(), filter_collision_data()$No__of_Casualties_Injured, tags$br(),
+    tags$b("Number of casualties: "), tags$br(), filter_collision_data()$No_of_Casualties_Injured, tags$br(),
     # Involved vehicle class
     tags$b("Involved vehicle classes: "), tags$br(), filter_collision_data()$vehicle_class_involved, tags$br(),
     # Involved casualty

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -201,9 +201,9 @@ ui <- dashboardPage(
 
               sliderInput(
                 inputId = "n_causality_filter", label = "No. of casualties",
-                min = min(hk_accidents$No__of_Casualties_Injured),
-                max = max(hk_accidents$No__of_Casualties_Injured),
-                value = range(hk_accidents$No__of_Casualties_Injured),
+                min = min(hk_accidents$No_of_Casualties_Injured),
+                max = max(hk_accidents$No_of_Casualties_Injured),
+                value = range(hk_accidents$No_of_Casualties_Injured),
                 step = 1
               )
             )

--- a/renv.lock
+++ b/renv.lock
@@ -249,10 +249,15 @@
     },
     "hkdatasets": {
       "Package": "hkdatasets",
-      "Version": "0.0.3",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "9e304aa4090ca6dbf58c6a88902e4baa"
+      "Version": "0.0.5",
+      "Source": "GitHub",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteRepo": "hkdatasets",
+      "RemoteUsername": "Hong-Kong-Districts-Info",
+      "RemoteRef": "HEAD",
+      "RemoteSha": "0893dcaaed17500331d497b5d012cac05c8df5ce",
+      "Hash": "26fabd245e8565b1509c8d74cb133fb4"
     },
     "htmltools": {
       "Package": "htmltools",

--- a/renv.lock
+++ b/renv.lock
@@ -408,6 +408,13 @@
       "Repository": "CRAN",
       "Hash": "f4dbc5a47fd93d3415249884d31d6791"
     },
+    "packrat": {
+      "Package": "packrat",
+      "Version": "0.6.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "0d6cc4c357e7602bb3eee299f4cfc2a5"
+    },
     "pillar": {
       "Package": "pillar",
       "Version": "1.6.1",
@@ -484,6 +491,20 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "515f341d3affe0de9e4a7f762efb0456"
+    },
+    "rsconnect": {
+      "Package": "rsconnect",
+      "Version": "0.8.24",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "5e21fd77eb844fa1ff1d23cb04e1d753"
+    },
+    "rstudioapi": {
+      "Package": "rstudioapi",
+      "Version": "0.13",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "06c85365a03fdaf699966cc1d3cf53ea"
     },
     "s2": {
       "Package": "s2",


### PR DESCRIPTION
# Summary
This branch bumps the **hkdatasets** dataset package used in this shiny app to the latest development version (https://github.com/Hong-Kong-Districts-Info/hkdatasets/commit/0893dcaaed17500331d497b5d012cac05c8df5ce).

# Changes
The changes made in this PR are:

1. Bump **hkdatasets** to the latest development version (https://github.com/Hong-Kong-Districts-Info/hkdatasets/commit/0893dcaaed17500331d497b5d012cac05c8df5ce)
1. Fix inconsistency of the variable names (`No__of_Casualties_Injured` -> `No_of_Casualties_Injured`)
1. Remove code for datetime formatting, as it is now implemented in https://github.com/Hong-Kong-Districts-Info/hkdatasets/commit/67a7dd0d4607c5ac0a55c871be96c3a371c5b7a7
1. Use the new `Date_Time` column to filter the dataset

***

# Check
- [ ] The filters of the collision location map are displayed correctly
- [ ] The popup of collision points are shown correctly (no **NA** etc.)
- [ ] The travis.ci and R CMD checks pass.
