### PR TITLE
Feat: Refine dashboard UI

### DIFF
--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -29,6 +29,6 @@ library(leaflet.extras)
 # Data import -------------------------------------------------------------
 
 ## Take data from {hkdatasets}
-hk_accidents <- hkdatasets::hk_accidents
+hk_accidents <- hkdatasets:::hk_accidents
 hk_vehicles <- hkdatasets::hk_vehicles
 hk_casualties <- hkdatasets::hk_casualties

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -24,21 +24,6 @@ hk_accidents_valid <- filter(hk_accidents_join, !is.na(latitude) & !is.na(longit
 # https://rstudio.github.io/leaflet/projections.html
 hk_accidents_valid_sf <- st_as_sf(x = hk_accidents_valid, coords = c("longitude", "latitude"), crs = 4326, remove = FALSE)
 
-# Need to convert to POSIXct again, otherwise reactive filtering does not work
-# TODO: investigate why
-hk_accidents_valid_sf$Date <- as.Date(hk_accidents_valid_sf$Date, format = "%Y-%m-%d")
-
-# Combine date and time together as a complete POSIXct class time column
-# Easier for formatting
-hk_accidents_valid_sf$Date_Time <- as.POSIXct(
-  strptime(
-    paste0(hk_accidents_valid_sf$Date, " ", hk_accidents_valid_sf$Time),
-    format = "%Y-%m-%d %H%M",
-    tz = "Asia/Hong_Kong"
-    )
-  )
-
-
 output$main_map <- renderLeaflet({
   overview_map <- leaflet() %>%
     setView(lng = 114.2, lat = 22.3, zoom = 12) %>%

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -53,7 +53,7 @@ output$nrow_filtered <- reactive(nrow(filter_collision_data()))
 # Filter the collision data according to users' input
 filter_collision_data <- reactive({
 
-  data_filtered = filter(hk_accidents_valid_sf, Date >= input$date_filter[1] & Date <= input$date_filter[2])
+  data_filtered = filter(hk_accidents_valid_sf, as.Date(Date_Time) >= input$date_filter[1] & as.Date(Date_Time) <= input$date_filter[2])
 
   data_filtered = filter(data_filtered,
                                 No_of_Casualties_Injured >= input$n_causality_filter[1] & No_of_Casualties_Injured <= input$n_causality_filter[2])

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -71,7 +71,7 @@ filter_collision_data <- reactive({
   data_filtered = filter(hk_accidents_valid_sf, Date >= input$date_filter[1] & Date <= input$date_filter[2])
 
   data_filtered = filter(data_filtered,
-                                No__of_Casualties_Injured >= input$n_causality_filter[1] & No__of_Casualties_Injured <= input$n_causality_filter[2])
+                                No_of_Casualties_Injured >= input$n_causality_filter[1] & No_of_Casualties_Injured <= input$n_causality_filter[2])
 
   data_filtered = filter(data_filtered, Type_of_Collision %in% input$collision_type_filter)
 
@@ -124,7 +124,7 @@ observe({
     # District
     tags$b("District: "), tags$br(), filter_collision_data()$District_Council_District, tags$br(),
     # Number of injuries
-    tags$b("Number of casualties: "), tags$br(), filter_collision_data()$No__of_Casualties_Injured, tags$br(),
+    tags$b("Number of casualties: "), tags$br(), filter_collision_data()$No_of_Casualties_Injured, tags$br(),
     # Involved vehicle class
     tags$b("Involved vehicle classes: "), tags$br(), filter_collision_data()$vehicle_class_involved, tags$br(),
     # Involved casualty

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -254,145 +254,151 @@ ui <- dashboardPage(
         tabBox(
           width = 12,
 
-          # All Vehicle Collision tab
-          tabPanel(
-            value = "all_vehicle_collision",
-            title = "All Vehicle Collision",
+          # Use tabsetPanel to observe which tab user is currently opening
+          # https://stackoverflow.com/questions/23243454/how-to-use-tabpanel-as-input-in-r-shiny
+          tabsetPanel(
+            id = "dashboard_collision_category",
 
-            fluidRow(
-              box(
+            # All Vehicle Collision tab
+            tabPanel(
+              value = "all_vehicle_collision",
+              title = "All Vehicle Collision",
+
+              fluidRow(
+                box(
+                    width = 6,
+                    title = "Collision Map",
+                    "Insert collison map here"
+                ),
+                box(width = 6,
+                    title = "KSI Stats",
+                    "Insert ksi stats here"
+                )
+              ),
+
+              fluidRow(
+                box(
+                  width = 4,
+                  title = "Vehicle Class vs Casualty Role Graph",
+                  "Insert vehicle class vs casualty role graph here"
+                ),
+                box(
+                  width = 4,
+                  title = "Junction and Road Stats",
+                  "Insert junction and role stats here"
+                ),
+                box(
+                  width = 4,
+                  title = "Collision Year Line Graph",
+                  "Insert collision year line graph here"
+                )
+              ),
+
+              fluidRow(
+                box(width = 6,
+                    title = "Contributory Factors Stats",
+                    "Insert contributory factors stats here"
+                ),
+                box(width = 6,
+                    title = "Accidents by Road Length Stats",
+                    "Insert accidents by road length stats here"
+                )
+              )
+            ),
+
+            # Vehicle w/ Peds tab
+            tabPanel(
+              value = "vehicle_with_pedestrians",
+              title = "Vehicle w/ Peds",
+
+              fluidRow(
+                box(
                   width = 6,
                   title = "Collision Map",
                   "Insert collison map here"
+                ),
+                box(width = 6,
+                    title = "KSI Stats",
+                    "Insert ksi stats here"
+                )
               ),
-              box(width = 6,
-                  title = "KSI Stats",
-                  "Insert ksi stats here"
+
+              fluidRow(
+                box(
+                  width = 3,
+                  title = "Vehicle Class Stats",
+                  "Insert vehicle class stats here"
+                ),
+                box(
+                  width = 3,
+                  title = "Vehicle Movement Stats",
+                  "Insert vehicle movement stats here"
+                ),
+                box(
+                  width = 3,
+                  title = "Pedestrian Action Stats",
+                  "Insert padestrian action stats here"
+                ),
+                box(
+                  width = 3,
+                  title = "Junction and Road Stats",
+                  "Insert junction and road stats here"
+                )
+              ),
+
+              fluidRow(
+                box(width = 12,
+                    title = "Contributory Factors Stats",
+                    "Insert contributory factors stats here"
+                )
               )
             ),
 
-            fluidRow(
-              box(
-                width = 4,
-                title = "Vehicle Class vs Casualty Role Graph",
-                "Insert vehicle class vs casualty role graph here"
-              ),
-              box(
-                width = 4,
-                title = "Junction and Road Stats",
-                "Insert junction and role stats here"
-              ),
-              box(
-                width = 4,
-                title = "Collision Year Line Graph",
-                "Insert collision year line graph here"
-              )
-            ),
+            # Vehicle w/ Cycles tab
+            tabPanel(
+              value = "vehicle_with_bicycles",
+              title = "Vehicle w/ Cycles",
 
-            fluidRow(
-              box(width = 6,
-                  title = "Contributory Factors Stats",
-                  "Insert contributory factors stats here"
+              fluidRow(
+                box(
+                  width = 6,
+                  title = "Collision Map",
+                  "Insert collison map here"
+                ),
+                box(width = 6,
+                    title = "KSI Stats",
+                    "Insert ksi stats here"
+                )
               ),
-              box(width = 6,
-                  title = "Accidents by Road Length Stats",
-                  "Insert accidents by road length stats here"
-              )
-            )
-          ),
 
-          # Vehicle w/ Peds tab
-          tabPanel(
-            value = "vehicle_with_pedestrians",
-            title = "Vehicle w/ Peds",
+              fluidRow(
+                box(
+                  width = 3,
+                  title = "Vehicle Class Stats",
+                  "Insert vehicle class stats here"
+                ),
+                box(
+                  width = 3,
+                  title = "Vehicle Movement Stats",
+                  "Insert vehicle movement stats here"
+                ),
+                box(
+                  width = 3,
+                  title = "Cyclist Action Stats",
+                  "Insert cyclist action stats here"
+                ),
+                box(
+                  width = 3,
+                  title = "Road Stats",
+                  "Insert road stats here"
+                )
+              ),
 
-            fluidRow(
-              box(
-                width = 6,
-                title = "Collision Map",
-                "Insert collison map here"
-              ),
-              box(width = 6,
-                  title = "KSI Stats",
-                  "Insert ksi stats here"
-              )
-            ),
-
-            fluidRow(
-              box(
-                width = 3,
-                title = "Vehicle Class Stats",
-                "Insert vehicle class stats here"
-              ),
-              box(
-                width = 3,
-                title = "Vehicle Movement Stats",
-                "Insert vehicle movement stats here"
-              ),
-              box(
-                width = 3,
-                title = "Pedestrian Action Stats",
-                "Insert padestrian action stats here"
-              ),
-              box(
-                width = 3,
-                title = "Junction and Road Stats",
-                "Insert junction and road stats here"
-              )
-            ),
-
-            fluidRow(
-              box(width = 12,
-                  title = "Contributory Factors Stats",
-                  "Insert contributory factors stats here"
-              )
-            )
-          ),
-
-          # Vehicle w/ Cycles tab
-          tabPanel(
-            value = "vehicle_with_bicycles",
-            title = "Vehicle w/ Cycles",
-
-            fluidRow(
-              box(
-                width = 6,
-                title = "Collision Map",
-                "Insert collison map here"
-              ),
-              box(width = 6,
-                  title = "KSI Stats",
-                  "Insert ksi stats here"
-              )
-            ),
-
-            fluidRow(
-              box(
-                width = 3,
-                title = "Vehicle Class Stats",
-                "Insert vehicle class stats here"
-              ),
-              box(
-                width = 3,
-                title = "Vehicle Movement Stats",
-                "Insert vehicle movement stats here"
-              ),
-              box(
-                width = 3,
-                title = "Cyclist Action Stats",
-                "Insert cyclist action stats here"
-              ),
-              box(
-                width = 3,
-                title = "Road Stats",
-                "Insert road stats here"
-              )
-            ),
-
-            fluidRow(
-              box(width = 12,
-                  title = "Contributory Factors Stats",
-                  "Insert contributory factors stats here"
+              fluidRow(
+                box(width = 12,
+                    title = "Contributory Factors Stats",
+                    "Insert contributory factors stats here"
+                )
               )
             )
           )

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -201,9 +201,9 @@ ui <- dashboardPage(
 
               sliderInput(
                 inputId = "n_causality_filter", label = "No. of casualties",
-                min = min(hk_accidents$No__of_Casualties_Injured),
-                max = max(hk_accidents$No__of_Casualties_Injured),
-                value = range(hk_accidents$No__of_Casualties_Injured),
+                min = min(hk_accidents$No_of_Casualties_Injured),
+                max = max(hk_accidents$No_of_Casualties_Injured),
+                value = range(hk_accidents$No_of_Casualties_Injured),
                 step = 1
               )
             )

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -231,6 +231,26 @@ ui <- dashboardPage(
 
       tabItem(
         tabName = "tab_dashboard",
+
+        # Filters
+        fluidRow(
+          box(
+            width = 4,
+            title = "Area Filter",
+            "Insert area filter here"
+          ),
+          box(
+            width = 4,
+            title = "Year Filter",
+            "Insert year filter here"
+          ),
+          box(
+            width = 4,
+            title = "All/ KSI Filter",
+            "Insert all/ksi filter here"
+          )
+        ),
+
         tabBox(
           width = 12,
 
@@ -238,24 +258,6 @@ ui <- dashboardPage(
           tabPanel(
             value = "all_vehicle_collision",
             title = "All Vehicle Collision",
-
-            fluidRow(
-              box(
-                width = 4,
-                title = "Area Filter",
-                "Insert area filter here"
-              ),
-              box(
-                width = 4,
-                title = "Year Filter",
-                "Insert year filter here"
-              ),
-              box(
-                width = 4,
-                title = "All/ KSI Filter",
-                "Insert all/ksi filter here"
-              )
-            ),
 
             fluidRow(
               box(
@@ -306,24 +308,6 @@ ui <- dashboardPage(
 
             fluidRow(
               box(
-                width = 4,
-                title = "Area Filter",
-                "Insert area filter here"
-              ),
-              box(
-                width = 4,
-                title = "Year Filter",
-                "Insert year filter here"
-              ),
-              box(
-                width = 4,
-                title = "All/ KSI Filter",
-                "Insert all/ksi filter here"
-              )
-            ),
-
-            fluidRow(
-              box(
                 width = 6,
                 title = "Collision Map",
                 "Insert collison map here"
@@ -369,24 +353,6 @@ ui <- dashboardPage(
           tabPanel(
             value = "vehicle_with_bicycles",
             title = "Vehicle w/ Cycles",
-
-            fluidRow(
-              box(
-                width = 4,
-                title = "Area Filter",
-                "Insert area filter here"
-              ),
-              box(
-                width = 4,
-                title = "Year Filter",
-                "Insert year filter here"
-              ),
-              box(
-                width = 4,
-                title = "All/ KSI Filter",
-                "Insert all/ksi filter here"
-              )
-            ),
 
             fluidRow(
               box(

--- a/renv.lock
+++ b/renv.lock
@@ -249,10 +249,15 @@
     },
     "hkdatasets": {
       "Package": "hkdatasets",
-      "Version": "0.0.3",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "9e304aa4090ca6dbf58c6a88902e4baa"
+      "Version": "0.0.5",
+      "Source": "GitHub",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteRepo": "hkdatasets",
+      "RemoteUsername": "Hong-Kong-Districts-Info",
+      "RemoteRef": "HEAD",
+      "RemoteSha": "0893dcaaed17500331d497b5d012cac05c8df5ce",
+      "Hash": "26fabd245e8565b1509c8d74cb133fb4"
     },
     "htmltools": {
       "Package": "htmltools",

--- a/renv.lock
+++ b/renv.lock
@@ -408,6 +408,13 @@
       "Repository": "CRAN",
       "Hash": "f4dbc5a47fd93d3415249884d31d6791"
     },
+    "packrat": {
+      "Package": "packrat",
+      "Version": "0.6.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "0d6cc4c357e7602bb3eee299f4cfc2a5"
+    },
     "pillar": {
       "Package": "pillar",
       "Version": "1.6.1",
@@ -484,6 +491,20 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "515f341d3affe0de9e4a7f762efb0456"
+    },
+    "rsconnect": {
+      "Package": "rsconnect",
+      "Version": "0.8.24",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "5e21fd77eb844fa1ff1d23cb04e1d753"
+    },
+    "rstudioapi": {
+      "Package": "rstudioapi",
+      "Version": "0.13",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "06c85365a03fdaf699966cc1d3cf53ea"
     },
     "s2": {
       "Package": "s2",


### PR DESCRIPTION
# Summary
This branch aims to refine the UI of the dashboard. It brings forward the proposed changes from #16.

### The original UI

![ui-dashboard-before](https://user-images.githubusercontent.com/29334677/131640165-4a285f8c-50f2-48b8-ab75-f3744b34855e.png)

### Proposed refined UI

![ui-dashboard-after](https://user-images.githubusercontent.com/29334677/131640153-38c8d5ef-44d2-4b47-9e4e-a054f87a9c24.png)


# Changes
The changes made in this PR are:

1. Merge 3 filters in each collision type (all collisions/pedestrian-related collision/cyclist-related collision) into single filter
1. Move filters to top of the dashboard page and visually separate the filters from the dashboard (filter panel vs. data viewer panel)
1. Wrap the whole dashboard tap inside a `tabsetPanel()` in order to track users' currently selected tab


***

# Check

- [ ] The travis.ci and R CMD checks pass.


