### PR TITLE
Feature: Refine dashboard UI 

### DIFF
--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -254,145 +254,151 @@ ui <- dashboardPage(
         tabBox(
           width = 12,
 
-          # All Vehicle Collision tab
-          tabPanel(
-            value = "all_vehicle_collision",
-            title = "All Vehicle Collision",
+          # Use tabsetPanel to observe which tab user is currently opening
+          # https://stackoverflow.com/questions/23243454/how-to-use-tabpanel-as-input-in-r-shiny
+          tabsetPanel(
+            id = "dashboard_collision_category",
 
-            fluidRow(
-              box(
+            # All Vehicle Collision tab
+            tabPanel(
+              value = "all_vehicle_collision",
+              title = "All Vehicle Collision",
+
+              fluidRow(
+                box(
+                    width = 6,
+                    title = "Collision Map",
+                    "Insert collison map here"
+                ),
+                box(width = 6,
+                    title = "KSI Stats",
+                    "Insert ksi stats here"
+                )
+              ),
+
+              fluidRow(
+                box(
+                  width = 4,
+                  title = "Vehicle Class vs Casualty Role Graph",
+                  "Insert vehicle class vs casualty role graph here"
+                ),
+                box(
+                  width = 4,
+                  title = "Junction and Road Stats",
+                  "Insert junction and role stats here"
+                ),
+                box(
+                  width = 4,
+                  title = "Collision Year Line Graph",
+                  "Insert collision year line graph here"
+                )
+              ),
+
+              fluidRow(
+                box(width = 6,
+                    title = "Contributory Factors Stats",
+                    "Insert contributory factors stats here"
+                ),
+                box(width = 6,
+                    title = "Accidents by Road Length Stats",
+                    "Insert accidents by road length stats here"
+                )
+              )
+            ),
+
+            # Vehicle w/ Peds tab
+            tabPanel(
+              value = "vehicle_with_pedestrians",
+              title = "Vehicle w/ Peds",
+
+              fluidRow(
+                box(
                   width = 6,
                   title = "Collision Map",
                   "Insert collison map here"
+                ),
+                box(width = 6,
+                    title = "KSI Stats",
+                    "Insert ksi stats here"
+                )
               ),
-              box(width = 6,
-                  title = "KSI Stats",
-                  "Insert ksi stats here"
+
+              fluidRow(
+                box(
+                  width = 3,
+                  title = "Vehicle Class Stats",
+                  "Insert vehicle class stats here"
+                ),
+                box(
+                  width = 3,
+                  title = "Vehicle Movement Stats",
+                  "Insert vehicle movement stats here"
+                ),
+                box(
+                  width = 3,
+                  title = "Pedestrian Action Stats",
+                  "Insert padestrian action stats here"
+                ),
+                box(
+                  width = 3,
+                  title = "Junction and Road Stats",
+                  "Insert junction and road stats here"
+                )
+              ),
+
+              fluidRow(
+                box(width = 12,
+                    title = "Contributory Factors Stats",
+                    "Insert contributory factors stats here"
+                )
               )
             ),
 
-            fluidRow(
-              box(
-                width = 4,
-                title = "Vehicle Class vs Casualty Role Graph",
-                "Insert vehicle class vs casualty role graph here"
-              ),
-              box(
-                width = 4,
-                title = "Junction and Road Stats",
-                "Insert junction and role stats here"
-              ),
-              box(
-                width = 4,
-                title = "Collision Year Line Graph",
-                "Insert collision year line graph here"
-              )
-            ),
+            # Vehicle w/ Cycles tab
+            tabPanel(
+              value = "vehicle_with_bicycles",
+              title = "Vehicle w/ Cycles",
 
-            fluidRow(
-              box(width = 6,
-                  title = "Contributory Factors Stats",
-                  "Insert contributory factors stats here"
+              fluidRow(
+                box(
+                  width = 6,
+                  title = "Collision Map",
+                  "Insert collison map here"
+                ),
+                box(width = 6,
+                    title = "KSI Stats",
+                    "Insert ksi stats here"
+                )
               ),
-              box(width = 6,
-                  title = "Accidents by Road Length Stats",
-                  "Insert accidents by road length stats here"
-              )
-            )
-          ),
 
-          # Vehicle w/ Peds tab
-          tabPanel(
-            value = "vehicle_with_pedestrians",
-            title = "Vehicle w/ Peds",
+              fluidRow(
+                box(
+                  width = 3,
+                  title = "Vehicle Class Stats",
+                  "Insert vehicle class stats here"
+                ),
+                box(
+                  width = 3,
+                  title = "Vehicle Movement Stats",
+                  "Insert vehicle movement stats here"
+                ),
+                box(
+                  width = 3,
+                  title = "Cyclist Action Stats",
+                  "Insert cyclist action stats here"
+                ),
+                box(
+                  width = 3,
+                  title = "Road Stats",
+                  "Insert road stats here"
+                )
+              ),
 
-            fluidRow(
-              box(
-                width = 6,
-                title = "Collision Map",
-                "Insert collison map here"
-              ),
-              box(width = 6,
-                  title = "KSI Stats",
-                  "Insert ksi stats here"
-              )
-            ),
-
-            fluidRow(
-              box(
-                width = 3,
-                title = "Vehicle Class Stats",
-                "Insert vehicle class stats here"
-              ),
-              box(
-                width = 3,
-                title = "Vehicle Movement Stats",
-                "Insert vehicle movement stats here"
-              ),
-              box(
-                width = 3,
-                title = "Pedestrian Action Stats",
-                "Insert padestrian action stats here"
-              ),
-              box(
-                width = 3,
-                title = "Junction and Road Stats",
-                "Insert junction and road stats here"
-              )
-            ),
-
-            fluidRow(
-              box(width = 12,
-                  title = "Contributory Factors Stats",
-                  "Insert contributory factors stats here"
-              )
-            )
-          ),
-
-          # Vehicle w/ Cycles tab
-          tabPanel(
-            value = "vehicle_with_bicycles",
-            title = "Vehicle w/ Cycles",
-
-            fluidRow(
-              box(
-                width = 6,
-                title = "Collision Map",
-                "Insert collison map here"
-              ),
-              box(width = 6,
-                  title = "KSI Stats",
-                  "Insert ksi stats here"
-              )
-            ),
-
-            fluidRow(
-              box(
-                width = 3,
-                title = "Vehicle Class Stats",
-                "Insert vehicle class stats here"
-              ),
-              box(
-                width = 3,
-                title = "Vehicle Movement Stats",
-                "Insert vehicle movement stats here"
-              ),
-              box(
-                width = 3,
-                title = "Cyclist Action Stats",
-                "Insert cyclist action stats here"
-              ),
-              box(
-                width = 3,
-                title = "Road Stats",
-                "Insert road stats here"
-              )
-            ),
-
-            fluidRow(
-              box(width = 12,
-                  title = "Contributory Factors Stats",
-                  "Insert contributory factors stats here"
+              fluidRow(
+                box(width = 12,
+                    title = "Contributory Factors Stats",
+                    "Insert contributory factors stats here"
+                )
               )
             )
           )

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -231,6 +231,26 @@ ui <- dashboardPage(
 
       tabItem(
         tabName = "tab_dashboard",
+
+        # Filters
+        fluidRow(
+          box(
+            width = 4,
+            title = "Area Filter",
+            "Insert area filter here"
+          ),
+          box(
+            width = 4,
+            title = "Year Filter",
+            "Insert year filter here"
+          ),
+          box(
+            width = 4,
+            title = "All/ KSI Filter",
+            "Insert all/ksi filter here"
+          )
+        ),
+
         tabBox(
           width = 12,
 
@@ -238,24 +258,6 @@ ui <- dashboardPage(
           tabPanel(
             value = "all_vehicle_collision",
             title = "All Vehicle Collision",
-
-            fluidRow(
-              box(
-                width = 4,
-                title = "Area Filter",
-                "Insert area filter here"
-              ),
-              box(
-                width = 4,
-                title = "Year Filter",
-                "Insert year filter here"
-              ),
-              box(
-                width = 4,
-                title = "All/ KSI Filter",
-                "Insert all/ksi filter here"
-              )
-            ),
 
             fluidRow(
               box(
@@ -306,24 +308,6 @@ ui <- dashboardPage(
 
             fluidRow(
               box(
-                width = 4,
-                title = "Area Filter",
-                "Insert area filter here"
-              ),
-              box(
-                width = 4,
-                title = "Year Filter",
-                "Insert year filter here"
-              ),
-              box(
-                width = 4,
-                title = "All/ KSI Filter",
-                "Insert all/ksi filter here"
-              )
-            ),
-
-            fluidRow(
-              box(
                 width = 6,
                 title = "Collision Map",
                 "Insert collison map here"
@@ -369,24 +353,6 @@ ui <- dashboardPage(
           tabPanel(
             value = "vehicle_with_bicycles",
             title = "Vehicle w/ Cycles",
-
-            fluidRow(
-              box(
-                width = 4,
-                title = "Area Filter",
-                "Insert area filter here"
-              ),
-              box(
-                width = 4,
-                title = "Year Filter",
-                "Insert year filter here"
-              ),
-              box(
-                width = 4,
-                title = "All/ KSI Filter",
-                "Insert all/ksi filter here"
-              )
-            ),
 
             fluidRow(
               box(


### PR DESCRIPTION
# Summary

This branch aims to refine the UI of the dashboard. It brings forward the proposed changes from #16.

### The original UI

![ui-dashboard-before](https://user-images.githubusercontent.com/29334677/131640165-4a285f8c-50f2-48b8-ab75-f3744b34855e.png)

### Proposed refined UI

![ui-dashboard-after](https://user-images.githubusercontent.com/29334677/131640153-38c8d5ef-44d2-4b47-9e4e-a054f87a9c24.png)


# Changes
The changes made in this PR are:

1. Merge 3 filters in each collision type (all collisions/pedestrian-related collision/cyclist-related collision) into single filter
1. Move filters to top of the dashboard page and visually separate the filters from the dashboard (filter panel vs. data viewer panel)
1. Wrap the whole dashboard tap inside a `tabsetPanel()` in order to track users' currently selected tab


***

# Check

- [x] The travis.ci and R CMD checks pass.

***

## Note
This PR is an updated version of #17.
