### PR TITLE
Feature: Cluster collision data on map view

### DIFF
--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -123,7 +123,7 @@ observe({
     clearMarkers() %>%
     addCircleMarkers(
       # fixed point size symbol
-      radius = 2.5,
+      radius = 7.5,
       color = "#FFFFFF", weight = 1, opacity = .75,
       fillColor = ~ fill_palette(Severity), fillOpacity = .75,
       popup = popup_template,

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -126,6 +126,9 @@ observe({
       radius = 2.5,
       color = "#FFFFFF", weight = 1, opacity = .75,
       fillColor = ~ fill_palette(Severity), fillOpacity = .75,
-      popup = popup_template
+      popup = popup_template,
+      clusterOptions = markerClusterOptions(
+        disableClusteringAtZoom = 16
       )
+    )
 })

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -121,6 +121,7 @@ observe({
 
   leafletProxy(mapId = "main_map", data = filter_collision_data()) %>%
     clearMarkers() %>%
+    clearMarkerClusters() %>%
     addCircleMarkers(
       # fixed point size symbol
       radius = 7.5,

--- a/inst/app/www/styles.css
+++ b/inst/app/www/styles.css
@@ -15,3 +15,32 @@
   opacity: 0.95;
   transition-delay: 0;
 }
+
+
+/* Change color of cluster markers on leaflet map */
+/* https://www.mapsmarker.com/kb/user-guide/how-to-change-the-color-of-marker-clusters/ */
+
+.marker-cluster-small {
+	background-color: rgba(170, 170, 170, 0.6) !important;
+}
+
+.marker-cluster-small div {
+	background-color: rgba(170, 170, 170, 0.6) !important;
+}
+
+.marker-cluster-medium {
+	background-color: rgba(170, 170, 170, 0.6) !important;
+}
+
+.marker-cluster-medium div {
+	background-color: rgba(170, 170, 170, 0.6) !important;
+}
+
+.marker-cluster-large {
+	background-color: rgba(170, 170, 170, 0.6) !important;
+}
+
+.marker-cluster-large div {
+	background-color: rgba(170, 170, 170, 0.6) !important;
+}
+


### PR DESCRIPTION
# Summary

This branch changes the map view of the collision map by clustering the collision data in zoom-out view.

# Changes

The changes made in this PR are:

1. Cluster collision points when the zoom level is smaller than 16 (~1:8,000, district-level zoom)

    https://user-images.githubusercontent.com/29334677/136853113-dd58a10f-ad36-438d-b96a-5f9766626856.mp4

1. Change the cluster marker to a uniform colour (currently light-gray), independent from the number of points within each cluster (which is leaflet's default option)

    ![cluster-points](https://user-images.githubusercontent.com/29334677/136852982-a03d273d-8439-41ea-8d4d-88af7bbe141f.png)

1. Increase point size from 2.5 to 7.5, making it easier for users to click on the point at high zoom level

    ![increase-point-size](https://user-images.githubusercontent.com/29334677/136852918-e58f4a11-a4c8-462c-90d4-54e2d768bff1.png)

***

# Check

- [x] The travis.ci and R CMD checks pass.
