### PR TITLE
Feature: Add charts and maps to cycle-related collision tab

### DIFF
--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -40,3 +40,7 @@ hk_casualties <- hkdatasets::hk_casualties
 
 tmap_mode("view")
 tmap_options(basemaps = c("CartoDB.Positron", "Stamen.TonerLite", "OpenStreetMap"))
+
+# Color scheme ------------------------------------------------------------
+
+SEVERITY_COLOR = c(Fatal = "#230B4C", Serious = "#C03A51", Slight = "#F1701E")

--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -32,7 +32,7 @@ library(tmap)
 # Data import -------------------------------------------------------------
 
 ## Take data from {hkdatasets}
-hk_accidents <- hkdatasets:::hk_accidents
+hk_accidents <- hkdatasets::hk_accidents
 hk_vehicles <- hkdatasets::hk_vehicles
 hk_casualties <- hkdatasets::hk_casualties
 

--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -25,6 +25,9 @@ library(sf)
 library(leaflet)
 library(leaflet.extras)
 
+## Thematic map
+library(tmap)
+
 
 # Data import -------------------------------------------------------------
 
@@ -32,3 +35,8 @@ library(leaflet.extras)
 hk_accidents <- hkdatasets:::hk_accidents
 hk_vehicles <- hkdatasets::hk_vehicles
 hk_casualties <- hkdatasets::hk_casualties
+
+# interactive thematic map mode option ------------------------------------
+
+tmap_mode("view")
+tmap_options(basemaps = c("CartoDB.Positron", "Stamen.TonerLite", "OpenStreetMap"))

--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -44,3 +44,4 @@ tmap_options(basemaps = c("CartoDB.Positron", "Stamen.TonerLite", "OpenStreetMap
 # Color scheme ------------------------------------------------------------
 
 SEVERITY_COLOR = c(Fatal = "#230B4C", Serious = "#C03A51", Slight = "#F1701E")
+CATEGORY_COLOR = setNames(as.list(c("#67B7DC", "#A367DC", "#FFAE12")), c("accidents", "casualties", "vehicles"))

--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -29,6 +29,6 @@ library(leaflet.extras)
 # Data import -------------------------------------------------------------
 
 ## Take data from {hkdatasets}
-hk_accidents <- hkdatasets::hk_accidents
+hk_accidents <- hkdatasets:::hk_accidents
 hk_vehicles <- hkdatasets::hk_vehicles
 hk_casualties <- hkdatasets::hk_casualties

--- a/inst/app/modules/district_dsb_all.R
+++ b/inst/app/modules/district_dsb_all.R
@@ -24,3 +24,21 @@ ddsb_filtered_hk_accidents = reactive({
   hk_accidents_filtered
 
 })
+
+# filtered hk_casualties
+ddsb_filtered_hk_casualties = reactive({
+
+  # vector of Serial No. in selected range
+  serial_no_filtered = unique(ddsb_filtered_hk_accidents()[["Serial_No_"]])
+
+  filter(hk_casualties, Serial_No_ %in% serial_no_filtered)
+})
+
+# filtered hk_vehicles
+ddsb_filtered_hk_vehicles = reactive({
+
+  # vector of Serial No. in selected range
+  serial_no_filtered = unique(ddsb_filtered_hk_accidents()[["Serial_No_"]])
+
+  filter(hk_vehicles, Serial_No_ %in% serial_no_filtered)
+})

--- a/inst/app/modules/district_dsb_all.R
+++ b/inst/app/modules/district_dsb_all.R
@@ -1,0 +1,26 @@
+# For filtering the dataset according to users' input filter
+# and visualise the dataset in the "all collisions" tab
+
+# Return filtered hk_accidents dataframe according to users' selected inputs
+ddsb_filtered_hk_accidents = reactive({
+  # filter by users' selected district
+  hk_accidents_filtered = filter(hk_accidents, District_Council_District == input$ddsb_district_filter)
+
+  # filter by users' selected time range
+  hk_accidents_filtered = filter(hk_accidents_filtered, Year >= input$ddsb_year_filter[1] & Year <= input$ddsb_year_filter[2])
+
+  # remove slightly injured collisions if user select "KSI only" option
+  if (input$ddsb_ksi_filter == "Killed or Seriously Injuries only") {
+    hk_accidents_filtered = filter(hk_accidents_filtered, Severity != "Slight")
+  }
+
+  # Show only collisions with valid lng/lat
+  hk_accidents_filtered = hk_accidents_filtered %>%
+    filter(!is.na(Grid_E) & !is.na(Grid_N)) %>%
+    st_as_sf(coords = c("Grid_E", "Grid_N"), crs = 2326, remove = FALSE)
+
+  print(nrow(hk_accidents_filtered))
+
+  hk_accidents_filtered
+
+})

--- a/inst/app/modules/district_dsb_all.R
+++ b/inst/app/modules/district_dsb_all.R
@@ -42,3 +42,26 @@ ddsb_filtered_hk_vehicles = reactive({
 
   filter(hk_vehicles, Serial_No_ %in% serial_no_filtered)
 })
+
+# Generate a spatial grid from the bounding box of points (i.e. collisions),
+# then count the number of points within each grid
+#
+# returns a sf class spatial grid with a count column named "n_colli"
+count_collisions_in_grid = function(point_data, grid_size = c(150, 150)) {
+  area_grid <- st_make_grid(point_data, grid_size, what = "polygons", square = TRUE)
+
+  # To sf and add grid ID
+  area_grid_count <- st_sf(area_grid) %>%
+    mutate(grid_id = 1:length(lengths(area_grid)))
+
+  # count number of points in each grid
+  # https://gis.stackexchange.com/questions/323698/counting-points-in-polygons-with-sf-package-of-r
+  area_grid_count$n_colli = lengths(st_intersects(area_grid_count, point_data))
+
+  # remove grid without accidents
+  area_grid_count = filter(area_grid_count, n_colli > 0)
+
+  # return the grid in sf format
+  area_grid_count
+}
+

--- a/inst/app/modules/district_dsb_cyc.R
+++ b/inst/app/modules/district_dsb_cyc.R
@@ -106,3 +106,27 @@ output$ddsb_cyc_collision_heatmap = renderTmap({
     tm_borders(col = "white", lwd = 0.7)
 
 })
+
+# Collision number by severity
+output$ddsb_cyc_ksi_plot = renderPlotly({
+
+  # count by severity
+  plot_data = count(ddsb_cyc_filtered_hk_accidents(), Severity, name = "count", na.rm = TRUE)
+
+  plot_by_severity = ggplot(plot_data, aes(x = Severity, y = count, fill = Severity)) +
+    geom_bar(stat = "identity") +
+    coord_flip() +
+    scale_fill_manual(values = SEVERITY_COLOR) +
+    theme_minimal() +
+    theme(
+      panel.grid.major.y = element_blank(),
+      panel.grid.minor.y = element_blank(),
+      legend.position = "none"
+    ) +
+    labs(
+      x = "",
+      title = "Collisions by Severity"
+    )
+
+  ggplotly(plot_by_severity)
+})

--- a/inst/app/modules/district_dsb_cyc.R
+++ b/inst/app/modules/district_dsb_cyc.R
@@ -156,3 +156,29 @@ output$ddsb_cyc_vehicle_class_plot = renderPlotly({
 
   ggplotly(plot_by_vehicle_class)
 })
+
+# Vehicle movement plot
+output$ddsb_cyc_vehicle_movement_plot = renderPlotly({
+
+  # count by Vehicle_Class
+  plot_data = count(ddsb_cyc_filtered_hk_vehicles(), Main_vehicle, name = "count") %>%
+    # reorder vehicle class in descending order
+    mutate(Main_vehicle_order = reorder(Main_vehicle, count))
+
+
+  plot_by_vehicle_movement = ggplot(plot_data, aes(x = Main_vehicle_order, y = count)) +
+    geom_bar(stat = "identity", fill = CATEGORY_COLOR$vehicles) +
+    coord_flip() +
+    theme_minimal() +
+    theme(
+      panel.grid.major.y = element_blank(),
+      panel.grid.minor.y = element_blank(),
+      legend.position = "none"
+    ) +
+    labs(
+      x = "",
+      title = "Vehicle movements at accident"
+    )
+
+  ggplotly(plot_by_vehicle_movement)
+})

--- a/inst/app/modules/district_dsb_cyc.R
+++ b/inst/app/modules/district_dsb_cyc.R
@@ -1,0 +1,31 @@
+# For filtering the dataset according to users' input filter
+# and visualise the dataset in the "collisions with bicycles" tab
+
+COLLISION_TYPE_WITH_CYCLES = c(
+  "Pedal Cycle collision with Nothing",
+  "Pedal Cycle collision with Pedestrian",
+  "Vehicle collision with Pedal Cycle",
+  "Pedal Cycle collision with Object",
+  "Pedal Cycle collision with Pedal Cycle"
+  )
+
+# Only return collisions with bicycles involved
+ddsb_cyc_filtered_hk_accidents = reactive({
+  filter(ddsb_filtered_hk_accidents(), Type_of_Collision_with_cycle %in% COLLISION_TYPE_WITH_CYCLES)
+})
+
+# filtered hk_casualties with bicycles involved only
+ddsb_cyc_filtered_hk_casualties = reactive({
+
+  serial_no_filtered = unique(ddsb_cyc_filtered_hk_accidents()[["Serial_No_"]])
+
+  filter(hk_casualties, Serial_No_ %in% serial_no_filtered)
+})
+
+# filtered hk_vehicles with bicycles involved only
+ddsb_cyc_filtered_hk_vehicles = reactive({
+
+  serial_no_filtered = unique(ddsb_cyc_filtered_hk_accidents()[["Serial_No_"]])
+
+  filter(hk_vehicles, Serial_No_ %in% serial_no_filtered)
+})

--- a/inst/app/modules/district_dsb_cyc.R
+++ b/inst/app/modules/district_dsb_cyc.R
@@ -29,3 +29,55 @@ ddsb_cyc_filtered_hk_vehicles = reactive({
 
   filter(hk_vehicles, Serial_No_ %in% serial_no_filtered)
 })
+
+# Outputs ----------------------------------
+
+output$box_cyc_total_collision = renderInfoBox({
+  n_collision = nrow(ddsb_cyc_filtered_hk_accidents())
+
+  infoBox(
+    title = "",
+    value = format(n_collision, big.mark=","),
+    subtitle = "Number of collisions in selection",
+    icon = icon("car-crash"),
+    color = "blue"
+  )
+})
+
+output$box_cyc_total_casualty = renderInfoBox({
+  n_casualty = nrow(ddsb_cyc_filtered_hk_casualties())
+
+  infoBox(
+    title = "",
+    value = format(n_casualty, big.mark=","),
+    subtitle = "Number of casualties in selection",
+    icon = icon("user-injured"),
+    color = "blue"
+  )
+})
+
+output$box_cyc_serious_stat = renderInfoBox({
+  n_serious = nrow(filter(ddsb_cyc_filtered_hk_casualties(), Degree_of_Injury == "Seriously Injured"))
+  serious_per = round(n_serious / nrow(ddsb_cyc_filtered_hk_casualties()) * 100, digits = 1)
+
+  infoBox(
+    title = "",
+    value = paste0(n_serious, " (", serious_per, "%)"),
+    subtitle = "Serious casualties / % of total",
+    icon = icon("procedures"),
+    color = "red"
+  )
+})
+
+output$box_cyc_fatal_stat = renderInfoBox({
+  n_fatal = nrow(filter(ddsb_cyc_filtered_hk_casualties(), Degree_of_Injury == "Killed"))
+  fatal_per = round(n_fatal / nrow(ddsb_cyc_filtered_hk_casualties()) * 100, digits = 1)
+
+  infoBox(
+    title = "",
+    subtitle = "Fatal casualties / % of total",
+    value = paste0(n_fatal, " (", fatal_per, "%)"),
+    icon = icon("skull-crossbones"),
+    color = "navy"
+  )
+})

--- a/inst/app/modules/district_dsb_cyc.R
+++ b/inst/app/modules/district_dsb_cyc.R
@@ -130,3 +130,29 @@ output$ddsb_cyc_ksi_plot = renderPlotly({
 
   ggplotly(plot_by_severity)
 })
+
+# Vehicle Class plot
+output$ddsb_cyc_vehicle_class_plot = renderPlotly({
+
+  # count by Vehicle_Class
+  plot_data = count(ddsb_cyc_filtered_hk_vehicles(), Vehicle_Class, name = "count", na.rm = TRUE) %>%
+    # reorder vehicle class in descending order
+    mutate(Vehicle_Class_order = reorder(Vehicle_Class, count))
+
+
+  plot_by_vehicle_class = ggplot(plot_data, aes(x = Vehicle_Class_order, y = count)) +
+    geom_bar(stat = "identity", fill = CATEGORY_COLOR$vehicles) +
+    coord_flip() +
+    theme_minimal() +
+    theme(
+      panel.grid.major.y = element_blank(),
+      panel.grid.minor.y = element_blank(),
+      legend.position = "none"
+    ) +
+    labs(
+      x = "",
+      title = "Number of vehicles involved"
+    )
+
+  ggplotly(plot_by_vehicle_class)
+})

--- a/inst/app/modules/district_dsb_cyc.R
+++ b/inst/app/modules/district_dsb_cyc.R
@@ -182,3 +182,31 @@ output$ddsb_cyc_vehicle_movement_plot = renderPlotly({
 
   ggplotly(plot_by_vehicle_movement)
 })
+
+# Road hierarchy plot
+output$ddsb_cyc_road_hierarchy_plot = renderPlotly({
+
+  # count by road hierarchy
+  plot_data = ddsb_cyc_filtered_hk_accidents() %>%
+    filter(!is.na(Road_Hierarchy)) %>%
+    count(Road_Hierarchy, name = "count") %>%
+    # reorder the drawing order from largest category
+    mutate(Road_Hierarchy_order = reorder(Road_Hierarchy, count))
+
+
+  plot_by_road_hierarchy = ggplot(plot_data, aes(x = Road_Hierarchy_order, y = count)) +
+    geom_bar(stat = "identity", fill = CATEGORY_COLOR$accidents) +
+    coord_flip() +
+    theme_minimal() +
+    theme(
+      panel.grid.major.y = element_blank(),
+      panel.grid.minor.y = element_blank(),
+      legend.position = "none"
+    ) +
+    labs(
+      x = "",
+      title = "Hierarchy of the road where collision happened"
+    )
+
+  ggplotly(plot_by_road_hierarchy)
+})

--- a/inst/app/modules/district_dsb_cyc.R
+++ b/inst/app/modules/district_dsb_cyc.R
@@ -30,6 +30,10 @@ ddsb_cyc_filtered_hk_vehicles = reactive({
   filter(hk_vehicles, Serial_No_ %in% serial_no_filtered)
 })
 
+cyc_grid_count = reactive({
+  count_collisions_in_grid(ddsb_cyc_filtered_hk_accidents())
+})
+
 # Outputs ----------------------------------
 
 output$box_cyc_total_collision = renderInfoBox({
@@ -80,4 +84,25 @@ output$box_cyc_fatal_stat = renderInfoBox({
     icon = icon("skull-crossbones"),
     color = "navy"
   )
+})
+
+
+# Interactive heatmap
+output$ddsb_cyc_collision_heatmap = renderTmap({
+
+  tm_shape(cyc_grid_count()) +
+    tm_fill(
+      col = "n_colli",
+      palette = "YlOrRd",
+      n = 10,
+      style = "cont",
+      title = "Number of collisions",
+      id = "n_colli",
+      showNA = FALSE,
+      alpha = 0.8,
+      # disable popups
+      popup.vars = FALSE,
+    ) +
+    tm_borders(col = "white", lwd = 0.7)
+
 })

--- a/inst/app/modules/district_dsb_ped.R
+++ b/inst/app/modules/district_dsb_ped.R
@@ -147,3 +147,29 @@ output$ddsb_ped_vehicle_class_plot = renderPlotly({
   ggplotly(plot_by_vehicle_class)
 })
 
+
+# Vehicle movement plot
+output$ddsb_ped_vehicle_movement_plot = renderPlotly({
+
+  # count by Vehicle_Class
+  plot_data = count(ddsb_ped_filtered_hk_vehicles(), Main_vehicle, name = "count") %>%
+    # reorder vehicle class in descending order
+    mutate(Main_vehicle_order = reorder(Main_vehicle, count))
+
+
+  plot_by_vehicle_movement = ggplot(plot_data, aes(x = Main_vehicle_order, y = count)) +
+    geom_bar(stat = "identity") +
+    coord_flip() +
+    theme_minimal() +
+    theme(
+      panel.grid.major.y = element_blank(),
+      panel.grid.minor.y = element_blank(),
+      legend.position = "none"
+    ) +
+    labs(
+      x = "",
+      title = "Vehicle movements at accident"
+    )
+
+  ggplotly(plot_by_vehicle_movement)
+})

--- a/inst/app/modules/district_dsb_ped.R
+++ b/inst/app/modules/district_dsb_ped.R
@@ -21,3 +21,54 @@ ddsb_ped_filtered_hk_vehicles = reactive({
 
   filter(hk_vehicles, Serial_No_ %in% serial_no_filtered)
 })
+
+
+# Outputs ----------------------------------
+
+output$box_ped_total_collision = renderValueBox({
+  n_collision = nrow(ddsb_ped_filtered_hk_accidents())
+
+  valueBox(
+    value = format(n_collision, big.mark=","),
+    subtitle = "Number of collisions in selection",
+    icon = icon("car-crash"),
+    color = "blue"
+  )
+})
+
+output$box_ped_total_casualty = renderValueBox({
+  n_casualty = nrow(ddsb_ped_filtered_hk_casualties())
+
+  valueBox(
+    value = format(n_casualty, big.mark=","),
+    subtitle = "Number of casualties in selection",
+    icon = icon("user-injured"),
+    color = "blue"
+  )
+})
+
+output$box_ped_serious_stat = renderValueBox({
+  n_serious = nrow(filter(ddsb_ped_filtered_hk_casualties(), Degree_of_Injury == "Seriously Injured"))
+  serious_per = round(n_serious / nrow(ddsb_ped_filtered_hk_casualties()) * 100, digits = 1)
+
+  valueBox(
+    value = paste0(n_serious, " (", serious_per, "%)"),
+    subtitle = "Serious casualties / % of total",
+    icon = icon("procedures"),
+    color = "red"
+  )
+})
+
+output$box_ped_fatal_stat = renderValueBox({
+  n_fatal = nrow(filter(ddsb_ped_filtered_hk_casualties(), Degree_of_Injury == "Killed"))
+  fatal_per = round(n_fatal / nrow(ddsb_ped_filtered_hk_casualties()) * 100, digits = 1)
+
+  valueBox(
+    value = paste0(n_fatal, " (", fatal_per, "%)"),
+    subtitle = "Fatal casualties / % of total",
+    # Change icon color manually
+    # Default color from shinydashboard.css is rgba(0, 0, 0, 0.15);
+    icon = tags$i(class = "fas fa-skull-crossbones", role = "presentation", style = "color: rgba(240, 240, 240, 0.15);"),
+    color = "navy"
+  )
+})

--- a/inst/app/modules/district_dsb_ped.R
+++ b/inst/app/modules/district_dsb_ped.R
@@ -22,6 +22,10 @@ ddsb_ped_filtered_hk_vehicles = reactive({
   filter(hk_vehicles, Serial_No_ %in% serial_no_filtered)
 })
 
+ped_grid_count = reactive({
+  count_collisions_in_grid(ddsb_ped_filtered_hk_accidents())
+})
+
 
 # Outputs ----------------------------------
 
@@ -72,3 +76,24 @@ output$box_ped_fatal_stat = renderValueBox({
     color = "navy"
   )
 })
+
+# Interactive heatmap
+output$ddsb_ped_collision_heatmap = renderTmap({
+
+  tm_shape(ped_grid_count()) +
+    tm_fill(
+      col = "n_colli",
+      palette = "YlOrRd",
+      n = 10,
+      style = "cont",
+      title = "Number of collisions",
+      id = "n_colli",
+      showNA = FALSE,
+      alpha = 0.8,
+      # disable popups
+      popup.vars = FALSE,
+    ) +
+    tm_borders(col = "white", lwd = 0.7)
+
+})
+

--- a/inst/app/modules/district_dsb_ped.R
+++ b/inst/app/modules/district_dsb_ped.R
@@ -105,7 +105,7 @@ output$ddsb_ped_collision_heatmap = renderTmap({
 output$ddsb_ped_ksi_plot = renderPlotly({
 
   # count by severity
-  plot_data = count(ddsb_ped_filtered_hk_accidents(), Severity, name = "count")
+  plot_data = count(ddsb_ped_filtered_hk_accidents(), Severity, name = "count", na.rm = TRUE)
 
   plot_by_severity = ggplot(plot_data, aes(x = Severity, y = count, fill = Severity)) +
     geom_bar(stat = "identity") +
@@ -129,7 +129,7 @@ output$ddsb_ped_ksi_plot = renderPlotly({
 output$ddsb_ped_vehicle_class_plot = renderPlotly({
 
   # count by Vehicle_Class
-  plot_data = count(ddsb_ped_filtered_hk_vehicles(), Vehicle_Class, name = "count") %>%
+  plot_data = count(ddsb_ped_filtered_hk_vehicles(), Vehicle_Class, name = "count", na.rm = TRUE) %>%
     # reorder vehicle class in descending order
     mutate(Vehicle_Class_order = reorder(Vehicle_Class, count))
 
@@ -182,7 +182,9 @@ output$ddsb_ped_vehicle_movement_plot = renderPlotly({
 output$ddsb_ped_ped_action_plot = renderPlotly({
 
   # count by pedestrian Action
-  plot_data = count(ddsb_ped_filtered_hk_casualties(), Ped_Action, name = "count") %>%
+  plot_data = ddsb_ped_filtered_hk_casualties() %>%
+    filter(!is.na(Ped_Action)) %>%
+    count(Ped_Action, name = "count") %>%
     # reorder the drawing order from largest category
     mutate(Ped_Action_order = reorder(Ped_Action, count))
 
@@ -208,7 +210,9 @@ output$ddsb_ped_ped_action_plot = renderPlotly({
 output$ddsb_ped_road_hierarchy_plot = renderPlotly({
 
   # count by pedestrian Action
-  plot_data = count(ddsb_ped_filtered_hk_accidents(), Road_Hierarchy, name = "count") %>%
+  plot_data = ddsb_ped_filtered_hk_accidents() %>%
+    filter(!is.na(Road_Hierarchy)) %>%
+    count(Road_Hierarchy, name = "count") %>%
     # reorder the drawing order from largest category
     mutate(Road_Hierarchy_order = reorder(Road_Hierarchy, count))
 

--- a/inst/app/modules/district_dsb_ped.R
+++ b/inst/app/modules/district_dsb_ped.R
@@ -120,3 +120,30 @@ output$ddsb_ped_ksi_plot = renderPlotly({
 
   ggplotly(plot_by_severity)
 })
+
+# Vehicle Class plot
+output$ddsb_ped_vehicle_class_plot = renderPlotly({
+
+  # count by Vehicle_Class
+  plot_data = count(ddsb_ped_filtered_hk_vehicles(), Vehicle_Class, name = "count") %>%
+    # reorder vehicle class in descending order
+    mutate(Vehicle_Class_order = reorder(Vehicle_Class, count))
+
+
+  plot_by_vehicle_class = ggplot(plot_data, aes(x = Vehicle_Class_order, y = count)) +
+    geom_bar(stat = "identity") +
+    coord_flip() +
+    theme_minimal() +
+    theme(
+      panel.grid.major.y = element_blank(),
+      panel.grid.minor.y = element_blank(),
+      legend.position = "none"
+    ) +
+    labs(
+      x = "",
+      title = "Number of vehicles involved"
+    )
+
+  ggplotly(plot_by_vehicle_class)
+})
+

--- a/inst/app/modules/district_dsb_ped.R
+++ b/inst/app/modules/district_dsb_ped.R
@@ -97,3 +97,26 @@ output$ddsb_ped_collision_heatmap = renderTmap({
 
 })
 
+# Collision number by severity
+output$ddsb_ped_ksi_plot = renderPlotly({
+
+  # count by severity
+  plot_data = count(ddsb_ped_filtered_hk_accidents(), Severity, name = "count")
+
+  plot_by_severity = ggplot(plot_data, aes(x = Severity, y = count, fill = Severity)) +
+    geom_bar(stat = "identity") +
+    coord_flip() +
+    scale_fill_manual(values = SEVERITY_COLOR) +
+    theme_minimal() +
+    theme(
+      panel.grid.major.y = element_blank(),
+      panel.grid.minor.y = element_blank(),
+      legend.position = "none"
+    ) +
+    labs(
+      x = "",
+      title = "Collisions by Severity"
+    )
+
+  ggplotly(plot_by_severity)
+})

--- a/inst/app/modules/district_dsb_ped.R
+++ b/inst/app/modules/district_dsb_ped.R
@@ -173,3 +173,29 @@ output$ddsb_ped_vehicle_movement_plot = renderPlotly({
 
   ggplotly(plot_by_vehicle_movement)
 })
+
+# Pedestrian Action plot
+output$ddsb_ped_ped_action_plot = renderPlotly({
+
+  # count by pedestrian Action
+  plot_data = count(ddsb_ped_filtered_hk_casualties(), Ped_Action, name = "count") %>%
+    # reorder the drawing order from largest category
+    mutate(Ped_Action_order = reorder(Ped_Action, count))
+
+
+  plot_by_ped_action = ggplot(plot_data, aes(x = Ped_Action_order, y = count)) +
+    geom_bar(stat = "identity") +
+    coord_flip() +
+    theme_minimal() +
+    theme(
+      panel.grid.major.y = element_blank(),
+      panel.grid.minor.y = element_blank(),
+      legend.position = "none"
+    ) +
+    labs(
+      x = "",
+      title = "Pedestrian action at accident"
+    )
+
+  ggplotly(plot_by_ped_action)
+})

--- a/inst/app/modules/district_dsb_ped.R
+++ b/inst/app/modules/district_dsb_ped.R
@@ -29,10 +29,11 @@ ped_grid_count = reactive({
 
 # Outputs ----------------------------------
 
-output$box_ped_total_collision = renderValueBox({
+output$box_ped_total_collision = renderInfoBox({
   n_collision = nrow(ddsb_ped_filtered_hk_accidents())
 
-  valueBox(
+  infoBox(
+    title = "",
     value = format(n_collision, big.mark=","),
     subtitle = "Number of collisions in selection",
     icon = icon("car-crash"),
@@ -40,10 +41,11 @@ output$box_ped_total_collision = renderValueBox({
   )
 })
 
-output$box_ped_total_casualty = renderValueBox({
+output$box_ped_total_casualty = renderInfoBox({
   n_casualty = nrow(ddsb_ped_filtered_hk_casualties())
 
-  valueBox(
+  infoBox(
+    title = "",
     value = format(n_casualty, big.mark=","),
     subtitle = "Number of casualties in selection",
     icon = icon("user-injured"),
@@ -51,11 +53,12 @@ output$box_ped_total_casualty = renderValueBox({
   )
 })
 
-output$box_ped_serious_stat = renderValueBox({
+output$box_ped_serious_stat = renderInfoBox({
   n_serious = nrow(filter(ddsb_ped_filtered_hk_casualties(), Degree_of_Injury == "Seriously Injured"))
   serious_per = round(n_serious / nrow(ddsb_ped_filtered_hk_casualties()) * 100, digits = 1)
 
-  valueBox(
+  infoBox(
+    title = "",
     value = paste0(n_serious, " (", serious_per, "%)"),
     subtitle = "Serious casualties / % of total",
     icon = icon("procedures"),
@@ -63,19 +66,20 @@ output$box_ped_serious_stat = renderValueBox({
   )
 })
 
-output$box_ped_fatal_stat = renderValueBox({
+output$box_ped_fatal_stat = renderInfoBox({
   n_fatal = nrow(filter(ddsb_ped_filtered_hk_casualties(), Degree_of_Injury == "Killed"))
   fatal_per = round(n_fatal / nrow(ddsb_ped_filtered_hk_casualties()) * 100, digits = 1)
 
-  valueBox(
-    value = paste0(n_fatal, " (", fatal_per, "%)"),
+  infoBox(
+    title = "",
     subtitle = "Fatal casualties / % of total",
-    # Change icon color manually
-    # Default color from shinydashboard.css is rgba(0, 0, 0, 0.15);
-    icon = tags$i(class = "fas fa-skull-crossbones", role = "presentation", style = "color: rgba(240, 240, 240, 0.15);"),
+    value = paste0(n_fatal, " (", fatal_per, "%)"),
+    icon = icon("skull-crossbones"),
     color = "navy"
   )
 })
+
+
 
 # Interactive heatmap
 output$ddsb_ped_collision_heatmap = renderTmap({

--- a/inst/app/modules/district_dsb_ped.R
+++ b/inst/app/modules/district_dsb_ped.R
@@ -1,0 +1,23 @@
+# For filtering the dataset according to users' input filter
+# and visualise the dataset in the "collisions with pedestrian" tab
+
+# Only return collisions with pedestrian involved
+ddsb_ped_filtered_hk_accidents = reactive({
+  filter(ddsb_filtered_hk_accidents(), Type_of_Collision == "Vehicle collision with Pedestrian")
+})
+
+# filtered hk_casualties with pedestrian involved only
+ddsb_ped_filtered_hk_casualties = reactive({
+
+  serial_no_filtered = unique(ddsb_ped_filtered_hk_accidents()[["Serial_No_"]])
+
+  filter(hk_casualties, Serial_No_ %in% serial_no_filtered)
+})
+
+# filtered hk_vehicles with pedestrian involved only
+ddsb_ped_filtered_hk_vehicles = reactive({
+
+  serial_no_filtered = unique(ddsb_ped_filtered_hk_accidents()[["Serial_No_"]])
+
+  filter(hk_vehicles, Serial_No_ %in% serial_no_filtered)
+})

--- a/inst/app/modules/district_dsb_ped.R
+++ b/inst/app/modules/district_dsb_ped.R
@@ -199,3 +199,29 @@ output$ddsb_ped_ped_action_plot = renderPlotly({
 
   ggplotly(plot_by_ped_action)
 })
+
+# Road hierarchy plot
+output$ddsb_ped_road_hierarchy_plot = renderPlotly({
+
+  # count by pedestrian Action
+  plot_data = count(ddsb_ped_filtered_hk_accidents(), Road_Hierarchy, name = "count") %>%
+    # reorder the drawing order from largest category
+    mutate(Road_Hierarchy_order = reorder(Road_Hierarchy, count))
+
+
+  plot_by_road_hierarchy = ggplot(plot_data, aes(x = Road_Hierarchy_order, y = count)) +
+    geom_bar(stat = "identity") +
+    coord_flip() +
+    theme_minimal() +
+    theme(
+      panel.grid.major.y = element_blank(),
+      panel.grid.minor.y = element_blank(),
+      legend.position = "none"
+    ) +
+    labs(
+      x = "",
+      title = "Hierarchy of the road where collision happened"
+    )
+
+  ggplotly(plot_by_road_hierarchy)
+})

--- a/inst/app/modules/district_dsb_ped.R
+++ b/inst/app/modules/district_dsb_ped.R
@@ -131,7 +131,7 @@ output$ddsb_ped_vehicle_class_plot = renderPlotly({
 
 
   plot_by_vehicle_class = ggplot(plot_data, aes(x = Vehicle_Class_order, y = count)) +
-    geom_bar(stat = "identity") +
+    geom_bar(stat = "identity", fill = CATEGORY_COLOR$vehicles) +
     coord_flip() +
     theme_minimal() +
     theme(
@@ -158,7 +158,7 @@ output$ddsb_ped_vehicle_movement_plot = renderPlotly({
 
 
   plot_by_vehicle_movement = ggplot(plot_data, aes(x = Main_vehicle_order, y = count)) +
-    geom_bar(stat = "identity") +
+    geom_bar(stat = "identity", fill = CATEGORY_COLOR$vehicles) +
     coord_flip() +
     theme_minimal() +
     theme(
@@ -184,7 +184,7 @@ output$ddsb_ped_ped_action_plot = renderPlotly({
 
 
   plot_by_ped_action = ggplot(plot_data, aes(x = Ped_Action_order, y = count)) +
-    geom_bar(stat = "identity") +
+    geom_bar(stat = "identity", fill = CATEGORY_COLOR$casualties) +
     coord_flip() +
     theme_minimal() +
     theme(
@@ -210,7 +210,7 @@ output$ddsb_ped_road_hierarchy_plot = renderPlotly({
 
 
   plot_by_road_hierarchy = ggplot(plot_data, aes(x = Road_Hierarchy_order, y = count)) +
-    geom_bar(stat = "identity") +
+    geom_bar(stat = "identity", fill = CATEGORY_COLOR$accidents) +
     coord_flip() +
     theme_minimal() +
     theme(

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -24,21 +24,6 @@ hk_accidents_valid <- filter(hk_accidents_join, !is.na(latitude) & !is.na(longit
 # https://rstudio.github.io/leaflet/projections.html
 hk_accidents_valid_sf <- st_as_sf(x = hk_accidents_valid, coords = c("longitude", "latitude"), crs = 4326, remove = FALSE)
 
-# Need to convert to POSIXct again, otherwise reactive filtering does not work
-# TODO: investigate why
-hk_accidents_valid_sf$Date <- as.Date(hk_accidents_valid_sf$Date, format = "%Y-%m-%d")
-
-# Combine date and time together as a complete POSIXct class time column
-# Easier for formatting
-hk_accidents_valid_sf$Date_Time <- as.POSIXct(
-  strptime(
-    paste0(hk_accidents_valid_sf$Date, " ", hk_accidents_valid_sf$Time),
-    format = "%Y-%m-%d %H%M",
-    tz = "Asia/Hong_Kong"
-    )
-  )
-
-
 output$main_map <- renderLeaflet({
   overview_map <- leaflet() %>%
     setView(lng = 114.2, lat = 22.3, zoom = 12) %>%

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -53,7 +53,7 @@ output$nrow_filtered <- reactive(nrow(filter_collision_data()))
 # Filter the collision data according to users' input
 filter_collision_data <- reactive({
 
-  data_filtered = filter(hk_accidents_valid_sf, Date >= input$date_filter[1] & Date <= input$date_filter[2])
+  data_filtered = filter(hk_accidents_valid_sf, as.Date(Date_Time) >= input$date_filter[1] & as.Date(Date_Time) <= input$date_filter[2])
 
   data_filtered = filter(data_filtered,
                                 No_of_Casualties_Injured >= input$n_causality_filter[1] & No_of_Casualties_Injured <= input$n_causality_filter[2])

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -71,7 +71,7 @@ filter_collision_data <- reactive({
   data_filtered = filter(hk_accidents_valid_sf, Date >= input$date_filter[1] & Date <= input$date_filter[2])
 
   data_filtered = filter(data_filtered,
-                                No__of_Casualties_Injured >= input$n_causality_filter[1] & No__of_Casualties_Injured <= input$n_causality_filter[2])
+                                No_of_Casualties_Injured >= input$n_causality_filter[1] & No_of_Casualties_Injured <= input$n_causality_filter[2])
 
   data_filtered = filter(data_filtered, Type_of_Collision %in% input$collision_type_filter)
 
@@ -124,7 +124,7 @@ observe({
     # District
     tags$b("District: "), tags$br(), filter_collision_data()$District_Council_District, tags$br(),
     # Number of injuries
-    tags$b("Number of casualties: "), tags$br(), filter_collision_data()$No__of_Casualties_Injured, tags$br(),
+    tags$b("Number of casualties: "), tags$br(), filter_collision_data()$No_of_Casualties_Injured, tags$br(),
     # Involved vehicle class
     tags$b("Involved vehicle classes: "), tags$br(), filter_collision_data()$vehicle_class_involved, tags$br(),
     # Involved casualty

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -27,6 +27,7 @@ server <- function(input, output, session) {
   # ----- TAB: Dashboard ----- #
   source(file = "modules/district_dsb_all.R", local = TRUE)
   source(file = "modules/district_dsb_ped.R", local = TRUE)
+  source(file = "modules/district_dsb_cyc.R", local = TRUE)
 
 
   # ----- TAB: Hotspots and Worst Roads ----- #

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -26,6 +26,7 @@ server <- function(input, output, session) {
 
   # ----- TAB: Dashboard ----- #
   source(file = "modules/district_dsb_all.R", local = TRUE)
+  source(file = "modules/district_dsb_ped.R", local = TRUE)
 
 
   # ----- TAB: Hotspots and Worst Roads ----- #

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -25,6 +25,7 @@ server <- function(input, output, session) {
 
 
   # ----- TAB: Dashboard ----- #
+  source(file = "modules/district_dsb_all.R", local = TRUE)
 
 
   # ----- TAB: Hotspots and Worst Roads ----- #

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -396,7 +396,7 @@ ui <- dashboardPage(
                 ),
                 box(width = 6,
                     title = "KSI Stats",
-                    "Insert ksi stats here"
+                    plotlyOutput(outputId = "ddsb_cyc_ksi_plot")
                 )
               ),
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -344,22 +344,25 @@ ui <- dashboardPage(
 
               fluidRow(
                 box(
-                  width = 3,
+                  width = 6,
                   title = "Vehicle Class Stats",
                   "Insert vehicle class stats here"
                 ),
                 box(
-                  width = 3,
+                  width = 6,
                   title = "Vehicle Movement Stats",
                   "Insert vehicle movement stats here"
-                ),
+                )
+              ),
+
+              fluidRow(
                 box(
-                  width = 3,
+                  width = 6,
                   title = "Pedestrian Action Stats",
                   "Insert padestrian action stats here"
                 ),
                 box(
-                  width = 3,
+                  width = 6,
                   title = "Junction and Road Stats",
                   "Insert junction and road stats here"
                 )
@@ -392,22 +395,25 @@ ui <- dashboardPage(
 
               fluidRow(
                 box(
-                  width = 3,
+                  width = 6,
                   title = "Vehicle Class Stats",
                   "Insert vehicle class stats here"
                 ),
                 box(
-                  width = 3,
+                  width = 6,
                   title = "Vehicle Movement Stats",
                   "Insert vehicle movement stats here"
-                ),
+                )
+              ),
+
+              fluidRow(
                 box(
-                  width = 3,
+                  width = 6,
                   title = "Cyclist Action Stats",
                   "Insert cyclist action stats here"
                 ),
                 box(
-                  width = 3,
+                  width = 6,
                   title = "Road Stats",
                   "Insert road stats here"
                 )

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -364,7 +364,7 @@ ui <- dashboardPage(
                 box(
                   width = 6,
                   title = "Junction and Road Stats",
-                  "Insert junction and road stats here"
+                  plotlyOutput(outputId = "ddsb_ped_road_hierarchy_plot")
                 )
               ),
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -359,7 +359,7 @@ ui <- dashboardPage(
                 box(
                   width = 6,
                   title = "Pedestrian Action Stats",
-                  "Insert padestrian action stats here"
+                  plotlyOutput(outputId = "ddsb_ped_ped_action_plot")
                 ),
                 box(
                   width = 6,

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -409,7 +409,7 @@ ui <- dashboardPage(
                 box(
                   width = 6,
                   title = "Vehicle Movement Stats",
-                  "Insert vehicle movement stats here"
+                  plotlyOutput(outputId = "ddsb_cyc_vehicle_movement_plot")
                 )
               ),
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -254,145 +254,151 @@ ui <- dashboardPage(
         tabBox(
           width = 12,
 
-          # All Vehicle Collision tab
-          tabPanel(
-            value = "all_vehicle_collision",
-            title = "All Vehicle Collision",
+          # Use tabsetPanel to observe which tab user is currently opening
+          # https://stackoverflow.com/questions/23243454/how-to-use-tabpanel-as-input-in-r-shiny
+          tabsetPanel(
+            id = "dashboard_collision_category",
 
-            fluidRow(
-              box(
+            # All Vehicle Collision tab
+            tabPanel(
+              value = "all_vehicle_collision",
+              title = "All Vehicle Collision",
+
+              fluidRow(
+                box(
+                    width = 6,
+                    title = "Collision Map",
+                    "Insert collison map here"
+                ),
+                box(width = 6,
+                    title = "KSI Stats",
+                    "Insert ksi stats here"
+                )
+              ),
+
+              fluidRow(
+                box(
+                  width = 4,
+                  title = "Vehicle Class vs Casualty Role Graph",
+                  "Insert vehicle class vs casualty role graph here"
+                ),
+                box(
+                  width = 4,
+                  title = "Junction and Road Stats",
+                  "Insert junction and role stats here"
+                ),
+                box(
+                  width = 4,
+                  title = "Collision Year Line Graph",
+                  "Insert collision year line graph here"
+                )
+              ),
+
+              fluidRow(
+                box(width = 6,
+                    title = "Contributory Factors Stats",
+                    "Insert contributory factors stats here"
+                ),
+                box(width = 6,
+                    title = "Accidents by Road Length Stats",
+                    "Insert accidents by road length stats here"
+                )
+              )
+            ),
+
+            # Vehicle w/ Peds tab
+            tabPanel(
+              value = "vehicle_with_pedestrians",
+              title = "Vehicle w/ Peds",
+
+              fluidRow(
+                box(
                   width = 6,
                   title = "Collision Map",
                   "Insert collison map here"
+                ),
+                box(width = 6,
+                    title = "KSI Stats",
+                    "Insert ksi stats here"
+                )
               ),
-              box(width = 6,
-                  title = "KSI Stats",
-                  "Insert ksi stats here"
+
+              fluidRow(
+                box(
+                  width = 3,
+                  title = "Vehicle Class Stats",
+                  "Insert vehicle class stats here"
+                ),
+                box(
+                  width = 3,
+                  title = "Vehicle Movement Stats",
+                  "Insert vehicle movement stats here"
+                ),
+                box(
+                  width = 3,
+                  title = "Pedestrian Action Stats",
+                  "Insert padestrian action stats here"
+                ),
+                box(
+                  width = 3,
+                  title = "Junction and Road Stats",
+                  "Insert junction and road stats here"
+                )
+              ),
+
+              fluidRow(
+                box(width = 12,
+                    title = "Contributory Factors Stats",
+                    "Insert contributory factors stats here"
+                )
               )
             ),
 
-            fluidRow(
-              box(
-                width = 4,
-                title = "Vehicle Class vs Casualty Role Graph",
-                "Insert vehicle class vs casualty role graph here"
-              ),
-              box(
-                width = 4,
-                title = "Junction and Road Stats",
-                "Insert junction and role stats here"
-              ),
-              box(
-                width = 4,
-                title = "Collision Year Line Graph",
-                "Insert collision year line graph here"
-              )
-            ),
+            # Vehicle w/ Cycles tab
+            tabPanel(
+              value = "vehicle_with_bicycles",
+              title = "Vehicle w/ Cycles",
 
-            fluidRow(
-              box(width = 6,
-                  title = "Contributory Factors Stats",
-                  "Insert contributory factors stats here"
+              fluidRow(
+                box(
+                  width = 6,
+                  title = "Collision Map",
+                  "Insert collison map here"
+                ),
+                box(width = 6,
+                    title = "KSI Stats",
+                    "Insert ksi stats here"
+                )
               ),
-              box(width = 6,
-                  title = "Accidents by Road Length Stats",
-                  "Insert accidents by road length stats here"
-              )
-            )
-          ),
 
-          # Vehicle w/ Peds tab
-          tabPanel(
-            value = "vehicle_with_pedestrians",
-            title = "Vehicle w/ Peds",
+              fluidRow(
+                box(
+                  width = 3,
+                  title = "Vehicle Class Stats",
+                  "Insert vehicle class stats here"
+                ),
+                box(
+                  width = 3,
+                  title = "Vehicle Movement Stats",
+                  "Insert vehicle movement stats here"
+                ),
+                box(
+                  width = 3,
+                  title = "Cyclist Action Stats",
+                  "Insert cyclist action stats here"
+                ),
+                box(
+                  width = 3,
+                  title = "Road Stats",
+                  "Insert road stats here"
+                )
+              ),
 
-            fluidRow(
-              box(
-                width = 6,
-                title = "Collision Map",
-                "Insert collison map here"
-              ),
-              box(width = 6,
-                  title = "KSI Stats",
-                  "Insert ksi stats here"
-              )
-            ),
-
-            fluidRow(
-              box(
-                width = 3,
-                title = "Vehicle Class Stats",
-                "Insert vehicle class stats here"
-              ),
-              box(
-                width = 3,
-                title = "Vehicle Movement Stats",
-                "Insert vehicle movement stats here"
-              ),
-              box(
-                width = 3,
-                title = "Pedestrian Action Stats",
-                "Insert padestrian action stats here"
-              ),
-              box(
-                width = 3,
-                title = "Junction and Road Stats",
-                "Insert junction and road stats here"
-              )
-            ),
-
-            fluidRow(
-              box(width = 12,
-                  title = "Contributory Factors Stats",
-                  "Insert contributory factors stats here"
-              )
-            )
-          ),
-
-          # Vehicle w/ Cycles tab
-          tabPanel(
-            value = "vehicle_with_bicycles",
-            title = "Vehicle w/ Cycles",
-
-            fluidRow(
-              box(
-                width = 6,
-                title = "Collision Map",
-                "Insert collison map here"
-              ),
-              box(width = 6,
-                  title = "KSI Stats",
-                  "Insert ksi stats here"
-              )
-            ),
-
-            fluidRow(
-              box(
-                width = 3,
-                title = "Vehicle Class Stats",
-                "Insert vehicle class stats here"
-              ),
-              box(
-                width = 3,
-                title = "Vehicle Movement Stats",
-                "Insert vehicle movement stats here"
-              ),
-              box(
-                width = 3,
-                title = "Cyclist Action Stats",
-                "Insert cyclist action stats here"
-              ),
-              box(
-                width = 3,
-                title = "Road Stats",
-                "Insert road stats here"
-              )
-            ),
-
-            fluidRow(
-              box(width = 12,
-                  title = "Contributory Factors Stats",
-                  "Insert contributory factors stats here"
+              fluidRow(
+                box(width = 12,
+                    title = "Contributory Factors Stats",
+                    "Insert contributory factors stats here"
+                )
               )
             )
           )

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -201,9 +201,9 @@ ui <- dashboardPage(
 
               sliderInput(
                 inputId = "n_causality_filter", label = "No. of casualties",
-                min = min(hk_accidents$No__of_Casualties_Injured),
-                max = max(hk_accidents$No__of_Casualties_Injured),
-                value = range(hk_accidents$No__of_Casualties_Injured),
+                min = min(hk_accidents$No_of_Casualties_Injured),
+                max = max(hk_accidents$No_of_Casualties_Injured),
+                value = range(hk_accidents$No_of_Casualties_Injured),
                 step = 1
               )
             )

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -201,9 +201,9 @@ ui <- dashboardPage(
 
               sliderInput(
                 inputId = "n_causality_filter", label = "No. of casualties",
-                min = min(hk_accidents$No_of_Casualties_Injured),
-                max = max(hk_accidents$No_of_Casualties_Injured),
-                value = range(hk_accidents$No_of_Casualties_Injured),
+                min = min(hk_accidents$No__of_Casualties_Injured),
+                max = max(hk_accidents$No__of_Casualties_Injured),
+                value = range(hk_accidents$No__of_Casualties_Injured),
                 step = 1
               )
             )

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -231,6 +231,26 @@ ui <- dashboardPage(
 
       tabItem(
         tabName = "tab_dashboard",
+
+        # Filters
+        fluidRow(
+          box(
+            width = 4,
+            title = "Area Filter",
+            "Insert area filter here"
+          ),
+          box(
+            width = 4,
+            title = "Year Filter",
+            "Insert year filter here"
+          ),
+          box(
+            width = 4,
+            title = "All/ KSI Filter",
+            "Insert all/ksi filter here"
+          )
+        ),
+
         tabBox(
           width = 12,
 
@@ -238,24 +258,6 @@ ui <- dashboardPage(
           tabPanel(
             value = "all_vehicle_collision",
             title = "All Vehicle Collision",
-
-            fluidRow(
-              box(
-                width = 4,
-                title = "Area Filter",
-                "Insert area filter here"
-              ),
-              box(
-                width = 4,
-                title = "Year Filter",
-                "Insert year filter here"
-              ),
-              box(
-                width = 4,
-                title = "All/ KSI Filter",
-                "Insert all/ksi filter here"
-              )
-            ),
 
             fluidRow(
               box(
@@ -306,24 +308,6 @@ ui <- dashboardPage(
 
             fluidRow(
               box(
-                width = 4,
-                title = "Area Filter",
-                "Insert area filter here"
-              ),
-              box(
-                width = 4,
-                title = "Year Filter",
-                "Insert year filter here"
-              ),
-              box(
-                width = 4,
-                title = "All/ KSI Filter",
-                "Insert all/ksi filter here"
-              )
-            ),
-
-            fluidRow(
-              box(
                 width = 6,
                 title = "Collision Map",
                 "Insert collison map here"
@@ -369,24 +353,6 @@ ui <- dashboardPage(
           tabPanel(
             value = "vehicle_with_bicycles",
             title = "Vehicle w/ Cycles",
-
-            fluidRow(
-              box(
-                width = 4,
-                title = "Area Filter",
-                "Insert area filter here"
-              ),
-              box(
-                width = 4,
-                title = "Year Filter",
-                "Insert year filter here"
-              ),
-              box(
-                width = 4,
-                title = "All/ KSI Filter",
-                "Insert all/ksi filter here"
-              )
-            ),
 
             fluidRow(
               box(

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -245,7 +245,13 @@ ui <- dashboardPage(
           box(
             width = 4,
             title = "Year Filter",
-            "Insert year filter here"
+            sliderInput(
+              inputId =  "ddsb_year_filter", label = "Select time period:",
+              min = 2014, max = 2019,
+              value = c(2015, 2019),
+              # Remove thousands separator
+              sep = ""
+            )
           ),
           box(
             width = 4,

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -404,7 +404,7 @@ ui <- dashboardPage(
                 box(
                   width = 6,
                   title = "Vehicle Class Stats",
-                  "Insert vehicle class stats here"
+                  plotlyOutput(outputId = "ddsb_cyc_vehicle_class_plot")
                 ),
                 box(
                   width = 6,

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -237,7 +237,10 @@ ui <- dashboardPage(
           box(
             width = 4,
             title = "Area Filter",
-            "Insert area filter here"
+            selectInput(
+              inputId = "ddsb_district_filter", label = "Select District",
+              choices = unique(hk_accidents$District_Council_District)
+            )
           ),
           box(
             width = 4,

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -324,10 +324,10 @@ ui <- dashboardPage(
               title = "Vehicle w/ Peds",
 
               fluidRow(
-                valueBoxOutput(width = 3, outputId = "box_ped_total_collision"),
-                valueBoxOutput(width = 3, outputId = "box_ped_total_casualty"),
-                valueBoxOutput(width = 3, outputId = "box_ped_serious_stat"),
-                valueBoxOutput(width = 3, outputId = "box_ped_fatal_stat")
+                infoBoxOutput(width = 3, outputId = "box_ped_total_collision"),
+                infoBoxOutput(width = 3, outputId = "box_ped_total_casualty"),
+                infoBoxOutput(width = 3, outputId = "box_ped_serious_stat"),
+                infoBoxOutput(width = 3, outputId = "box_ped_fatal_stat")
               ),
 
               fluidRow(

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -392,7 +392,7 @@ ui <- dashboardPage(
                 box(
                   width = 6,
                   title = "Collision Map",
-                  "Insert collison map here"
+                  tmapOutput(outputId = "ddsb_cyc_collision_heatmap")
                 ),
                 box(width = 6,
                     title = "KSI Stats",

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -256,7 +256,10 @@ ui <- dashboardPage(
           box(
             width = 4,
             title = "All/ KSI Filter",
-            "Insert all/ksi filter here"
+            selectInput(
+              inputId = "ddsb_ksi_filter", label = "Select collision severity category",
+              choices = c("All", "Killed or Seriously Injuries only")
+            )
           )
         ),
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -324,6 +324,13 @@ ui <- dashboardPage(
               title = "Vehicle w/ Peds",
 
               fluidRow(
+                valueBoxOutput(width = 3, outputId = "box_ped_total_collision"),
+                valueBoxOutput(width = 3, outputId = "box_ped_total_casualty"),
+                valueBoxOutput(width = 3, outputId = "box_ped_serious_stat"),
+                valueBoxOutput(width = 3, outputId = "box_ped_fatal_stat")
+              ),
+
+              fluidRow(
                 box(
                   width = 6,
                   title = "Collision Map",

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -338,7 +338,7 @@ ui <- dashboardPage(
                 ),
                 box(width = 6,
                     title = "KSI Stats",
-                    "Insert ksi stats here"
+                    plotlyOutput(outputId = "ddsb_ped_ksi_plot")
                 )
               ),
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -422,7 +422,7 @@ ui <- dashboardPage(
                 box(
                   width = 6,
                   title = "Road Stats",
-                  "Insert road stats here"
+                  plotlyOutput(outputId = "ddsb_cyc_road_hierarchy_plot")
                 )
               ),
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -351,7 +351,7 @@ ui <- dashboardPage(
                 box(
                   width = 6,
                   title = "Vehicle Movement Stats",
-                  "Insert vehicle movement stats here"
+                  plotlyOutput(outputId = "ddsb_ped_vehicle_movement_plot")
                 )
               ),
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -382,6 +382,13 @@ ui <- dashboardPage(
               title = "Vehicle w/ Cycles",
 
               fluidRow(
+                infoBoxOutput(width = 3, outputId = "box_cyc_total_collision"),
+                infoBoxOutput(width = 3, outputId = "box_cyc_total_casualty"),
+                infoBoxOutput(width = 3, outputId = "box_cyc_serious_stat"),
+                infoBoxOutput(width = 3, outputId = "box_cyc_fatal_stat")
+              ),
+
+              fluidRow(
                 box(
                   width = 6,
                   title = "Collision Map",

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -346,7 +346,7 @@ ui <- dashboardPage(
                 box(
                   width = 6,
                   title = "Vehicle Class Stats",
-                  "Insert vehicle class stats here"
+                  plotlyOutput(outputId = "ddsb_ped_vehicle_class_plot")
                 ),
                 box(
                   width = 6,

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -334,7 +334,7 @@ ui <- dashboardPage(
                 box(
                   width = 6,
                   title = "Collision Map",
-                  "Insert collison map here"
+                  tmapOutput(outputId = "ddsb_ped_collision_heatmap")
                 ),
                 box(width = 6,
                     title = "KSI Stats",

--- a/renv.lock
+++ b/renv.lock
@@ -249,10 +249,15 @@
     },
     "hkdatasets": {
       "Package": "hkdatasets",
-      "Version": "0.0.3",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "9e304aa4090ca6dbf58c6a88902e4baa"
+      "Version": "0.0.5",
+      "Source": "GitHub",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteRepo": "hkdatasets",
+      "RemoteUsername": "Hong-Kong-Districts-Info",
+      "RemoteRef": "HEAD",
+      "RemoteSha": "0893dcaaed17500331d497b5d012cac05c8df5ce",
+      "Hash": "26fabd245e8565b1509c8d74cb133fb4"
     },
     "htmltools": {
       "Package": "htmltools",

--- a/renv.lock
+++ b/renv.lock
@@ -249,15 +249,10 @@
     },
     "hkdatasets": {
       "Package": "hkdatasets",
-      "Version": "0.0.5",
-      "Source": "GitHub",
-      "RemoteType": "github",
-      "RemoteHost": "api.github.com",
-      "RemoteRepo": "hkdatasets",
-      "RemoteUsername": "Hong-Kong-Districts-Info",
-      "RemoteRef": "HEAD",
-      "RemoteSha": "0893dcaaed17500331d497b5d012cac05c8df5ce",
-      "Hash": "26fabd245e8565b1509c8d74cb133fb4"
+      "Version": "0.0.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "9e304aa4090ca6dbf58c6a88902e4baa"
     },
     "htmltools": {
       "Package": "htmltools",
@@ -413,13 +408,6 @@
       "Repository": "CRAN",
       "Hash": "f4dbc5a47fd93d3415249884d31d6791"
     },
-    "packrat": {
-      "Package": "packrat",
-      "Version": "0.6.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "0d6cc4c357e7602bb3eee299f4cfc2a5"
-    },
     "pillar": {
       "Package": "pillar",
       "Version": "1.6.1",
@@ -496,20 +484,6 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "515f341d3affe0de9e4a7f762efb0456"
-    },
-    "rsconnect": {
-      "Package": "rsconnect",
-      "Version": "0.8.24",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "5e21fd77eb844fa1ff1d23cb04e1d753"
-    },
-    "rstudioapi": {
-      "Package": "rstudioapi",
-      "Version": "0.13",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "06c85365a03fdaf699966cc1d3cf53ea"
     },
     "s2": {
       "Package": "s2",


### PR DESCRIPTION
# Summary

This branch adds the basic dashboard widgets for the "collision related to cycle" tab. This branch is mostly similar to #18. The difference is that this PR focuses the "collision w/ cycle" tab, while #18 is on the "collision w/ pedestrian" tab. 

# Changes

(Please refer to #18 for images, as the chart types and layout are the same)

The changes made in this PR are:

1. Add 4 boxes on top of the dashboard to show major statistics from the datasets user have filtered. Current major statistics include 1. total number of collisions; 2. total number of casualties; 3. number of serious casualties and 4. number of fatal casualties.
1. Add an interactive heatmap showing the number of collisions
1. Add bar charts that classify the collisions/casualties/vehicles according to different categorical variables

***

# Check

- [x] The travis.ci and R CMD checks pass.

***

## Note

Refactoring could be considered after charts and maps from all 3 tabs (all collision/pedestrian collision/cycle collision) are added. The code for generating interactive charts are similar.
