### PR TITLE
Fix: Add "cycle track" category in road hierarchy plot for cycle-related collision

### DIFF
--- a/inst/app/modules/district_dsb_cyc.R
+++ b/inst/app/modules/district_dsb_cyc.R
@@ -188,7 +188,10 @@ output$ddsb_cyc_road_hierarchy_plot = renderPlotly({
 
   # count by road hierarchy
   plot_data = ddsb_cyc_filtered_hk_accidents() %>%
-    filter(!is.na(Road_Hierarchy)) %>%
+    # For cycle-related collisions, Road_Hierarchy == -99 in original data (transformed in NA)
+    # implies the collision happened in cycle track
+    # Most cycle-related collisions with Road_Hierarchy of NA are actually happened in cycle tracks
+    mutate(Road_Hierarchy = ifelse(is.na(Road_Hierarchy), "Cycle Track/Others", Road_Hierarchy)) %>%
     count(Road_Hierarchy, name = "count") %>%
     # reorder the drawing order from largest category
     mutate(Road_Hierarchy_order = reorder(Road_Hierarchy, count))


### PR DESCRIPTION
# Summary

This branch adds "cycle track" category in road hierarchy plot for cycle-related collision.

# Changes

The changes made in this PR are:

1. For cycle-related collisions, change `NA` in *Road_Hierarchy* column to `Cycle Track/Others`
2. Add `Cycle Track/Others` category to the road hierarchy plot

![road-hierarchy-cycle-cat](https://user-images.githubusercontent.com/29334677/144827632-c68c4bf4-b64b-4159-a025-60ab1d96ab37.png)

***

# Check

- [x] The travis.ci and R CMD checks pass.

***

## Note

In the original raw data, cycle tracks are assigned with value of `-99` in the Road_Hierarchy column. They are transformed to NA when importing the data to **hkdatasets** package.