### PR TITLE
Feature: Add fundamental charts and map to "all collisions" tab

### DIFF
--- a/inst/app/modules/district_dsb_all.R
+++ b/inst/app/modules/district_dsb_all.R
@@ -43,6 +43,10 @@ ddsb_filtered_hk_vehicles = reactive({
   filter(hk_vehicles, Serial_No_ %in% serial_no_filtered)
 })
 
+all_grid_count = reactive({
+  count_collisions_in_grid(ddsb_filtered_hk_accidents())
+})
+
 # Generate a spatial grid from the bounding box of points (i.e. collisions),
 # then count the number of points within each grid
 #
@@ -64,7 +68,6 @@ count_collisions_in_grid = function(point_data, grid_size = c(150, 150)) {
   # return the grid in sf format
   area_grid_count
 }
-
 
 
 # Outputs ----------------------------------
@@ -117,5 +120,25 @@ output$box_all_fatal_stat = renderInfoBox({
     icon = icon("skull-crossbones"),
     color = "navy"
   )
+})
+
+# Interactive heatmap
+output$ddsb_all_collision_heatmap = renderTmap({
+
+  tm_shape(all_grid_count()) +
+    tm_fill(
+      col = "n_colli",
+      palette = "YlOrRd",
+      n = 10,
+      style = "cont",
+      title = "Number of collisions",
+      id = "n_colli",
+      showNA = FALSE,
+      alpha = 0.8,
+      # disable popups
+      popup.vars = FALSE,
+    ) +
+    tm_borders(col = "white", lwd = 0.7)
+
 })
 

--- a/inst/app/modules/district_dsb_all.R
+++ b/inst/app/modules/district_dsb_all.R
@@ -196,3 +196,31 @@ output$ddsb_all_year_plot = renderPlotly({
   out_plot
 
 })
+
+# Road hierarchy plot
+output$ddsb_all_road_hierarchy_plot = renderPlotly({
+
+  # count by pedestrian Action
+  plot_data = ddsb_filtered_hk_accidents() %>%
+    filter(!is.na(Road_Hierarchy)) %>%
+    count(Road_Hierarchy, name = "count") %>%
+    # reorder the drawing order from largest category
+    mutate(Road_Hierarchy_order = reorder(Road_Hierarchy, count))
+
+
+  plot_by_road_hierarchy = ggplot(plot_data, aes(x = Road_Hierarchy_order, y = count)) +
+    geom_bar(stat = "identity", fill = CATEGORY_COLOR$accidents) +
+    coord_flip() +
+    theme_minimal() +
+    theme(
+      panel.grid.major.y = element_blank(),
+      panel.grid.minor.y = element_blank(),
+      legend.position = "none"
+    ) +
+    labs(
+      x = "",
+      title = "Hierarchy of the road where collision happened"
+    )
+
+  ggplotly(plot_by_road_hierarchy)
+})

--- a/inst/app/modules/district_dsb_all.R
+++ b/inst/app/modules/district_dsb_all.R
@@ -166,3 +166,22 @@ output$ddsb_all_ksi_plot = renderPlotly({
   ggplotly(plot_by_severity)
 })
 
+# Collision by year plot
+output$ddsb_all_year_plot = renderPlotly({
+
+  selected_district_data = filter(hk_accidents, District_Council_District == input$ddsb_district_filter)
+
+  plot_data = count(selected_district_data, Year, name = "count", na.rm = TRUE)
+
+  collision_year_trend_plot = ggplot(plot_data, aes(x = Year, y = count)) +
+    geom_line() +
+    theme_minimal() +
+    scale_y_continuous(limits = c(0, NA)) +
+    labs(
+      x = "Year",
+      title = "Trend of collision in selected district"
+    )
+
+  ggplotly(collision_year_trend_plot)
+
+})

--- a/inst/app/modules/district_dsb_all.R
+++ b/inst/app/modules/district_dsb_all.R
@@ -65,3 +65,57 @@ count_collisions_in_grid = function(point_data, grid_size = c(150, 150)) {
   area_grid_count
 }
 
+
+
+# Outputs ----------------------------------
+
+output$box_all_total_collision = renderInfoBox({
+  n_collision = nrow(ddsb_filtered_hk_accidents())
+
+  infoBox(
+    title = "",
+    value = format(n_collision, big.mark=","),
+    subtitle = "Number of collisions in selection",
+    icon = icon("car-crash"),
+    color = "blue"
+  )
+})
+
+output$box_all_total_casualty = renderInfoBox({
+  n_casualty = nrow(ddsb_filtered_hk_casualties())
+
+  infoBox(
+    title = "",
+    value = format(n_casualty, big.mark=","),
+    subtitle = "Number of casualties in selection",
+    icon = icon("user-injured"),
+    color = "blue"
+  )
+})
+
+output$box_all_serious_stat = renderInfoBox({
+  n_serious = nrow(filter(ddsb_filtered_hk_casualties(), Degree_of_Injury == "Seriously Injured"))
+  serious_per = round(n_serious / nrow(ddsb_filtered_hk_casualties()) * 100, digits = 1)
+
+  infoBox(
+    title = "",
+    value = paste0(n_serious, " (", serious_per, "%)"),
+    subtitle = "Serious casualties / % of total",
+    icon = icon("procedures"),
+    color = "red"
+  )
+})
+
+output$box_all_fatal_stat = renderInfoBox({
+  n_fatal = nrow(filter(ddsb_filtered_hk_casualties(), Degree_of_Injury == "Killed"))
+  fatal_per = round(n_fatal / nrow(ddsb_filtered_hk_casualties()) * 100, digits = 1)
+
+  infoBox(
+    title = "",
+    subtitle = "Fatal casualties / % of total",
+    value = paste0(n_fatal, " (", fatal_per, "%)"),
+    icon = icon("skull-crossbones"),
+    color = "navy"
+  )
+})
+

--- a/inst/app/modules/district_dsb_all.R
+++ b/inst/app/modules/district_dsb_all.R
@@ -142,3 +142,27 @@ output$ddsb_all_collision_heatmap = renderTmap({
 
 })
 
+# Collision number by severity
+output$ddsb_all_ksi_plot = renderPlotly({
+
+  # count by severity
+  plot_data = count(ddsb_filtered_hk_accidents(), Severity, name = "count", na.rm = TRUE)
+
+  plot_by_severity = ggplot(plot_data, aes(x = Severity, y = count, fill = Severity)) +
+    geom_bar(stat = "identity") +
+    coord_flip() +
+    scale_fill_manual(values = SEVERITY_COLOR) +
+    theme_minimal() +
+    theme(
+      panel.grid.major.y = element_blank(),
+      panel.grid.minor.y = element_blank(),
+      legend.position = "none"
+    ) +
+    labs(
+      x = "",
+      title = "Collisions by Severity"
+    )
+
+  ggplotly(plot_by_severity)
+})
+

--- a/inst/app/modules/district_dsb_all.R
+++ b/inst/app/modules/district_dsb_all.R
@@ -171,9 +171,14 @@ output$ddsb_all_year_plot = renderPlotly({
 
   selected_district_data = filter(hk_accidents, District_Council_District == input$ddsb_district_filter)
 
+  year_min = input$ddsb_year_filter[1]
+  year_max = input$ddsb_year_filter[2]
+
   plot_data = count(selected_district_data, Year, name = "count", na.rm = TRUE)
 
   collision_year_trend_plot = ggplot(plot_data, aes(x = Year, y = count)) +
+    # ggplotly does not support `ymin = -Inf, ymax = Inf`
+    annotate("rect", xmin = year_min, xmax = year_max, ymin = 0, ymax = max(plot_data$count), alpha = .2, fill = "red") +
     geom_line() +
     theme_minimal() +
     scale_y_continuous(limits = c(0, NA)) +
@@ -182,6 +187,12 @@ output$ddsb_all_year_plot = renderPlotly({
       title = "Trend of collision in selected district"
     )
 
-  ggplotly(collision_year_trend_plot)
+  out_plot = ggplotly(collision_year_trend_plot)
+
+  # Disable tooltip of the annotation geom
+  # https://stackoverflow.com/questions/45801389/disable-hover-information-for-a-specific-layer-geom-of-plotly
+  out_plot$x$data[[1]]$hoverinfo <- "none"
+
+  out_plot
 
 })

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -283,7 +283,7 @@ ui <- dashboardPage(
                 box(
                   width = 6,
                   title = "Junction and Road Stats",
-                  "Insert junction and role stats here"
+                  plotlyOutput(outputId = "ddsb_all_road_hierarchy_plot")
                 )
               ),
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -261,30 +261,35 @@ ui <- dashboardPage(
 
               fluidRow(
                 box(
-                  width = 4,
-                  title = "Vehicle Class vs Casualty Role Graph",
-                  "Insert vehicle class vs casualty role graph here"
-                ),
-                box(
-                  width = 4,
-                  title = "Junction and Road Stats",
-                  "Insert junction and role stats here"
-                ),
-                box(
-                  width = 4,
+                  width = 12,
                   title = "Collision Year Line Graph",
                   "Insert collision year line graph here"
                 )
               ),
 
               fluidRow(
-                box(width = 6,
-                    title = "Contributory Factors Stats",
-                    "Insert contributory factors stats here"
+                box(
+                  width = 6,
+                  title = "Vehicle Class vs Casualty Role Graph",
+                  "Insert vehicle class vs casualty role graph here"
                 ),
-                box(width = 6,
-                    title = "Accidents by Road Length Stats",
-                    "Insert accidents by road length stats here"
+                box(
+                  width = 6,
+                  title = "Junction and Road Stats",
+                  "Insert junction and role stats here"
+                )
+              ),
+
+              fluidRow(
+                box(
+                  width = 6,
+                  title = "Contributory Factors Stats",
+                  "Insert contributory factors stats here"
+                ),
+                box(
+                  width = 6,
+                  title = "Accidents by Road Length Stats",
+                  "Insert accidents by road length stats here"
                 )
               )
             ),
@@ -346,7 +351,7 @@ ui <- dashboardPage(
                 )
               )
             ),
-            
+
             # Vehicle w/ Cycles tab
             tabPanel(
               value = "vehicle_with_bicycles",

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -258,7 +258,7 @@ ui <- dashboardPage(
                 box(
                     width = 6,
                     title = "Collision Map",
-                    "Insert collison map here"
+                    tmapOutput(outputId = "ddsb_all_collision_heatmap")
                 ),
                 box(width = 6,
                     title = "KSI Stats",

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -262,7 +262,7 @@ ui <- dashboardPage(
                 ),
                 box(width = 6,
                     title = "KSI Stats",
-                    "Insert ksi stats here"
+                    plotlyOutput(outputId = "ddsb_all_ksi_plot")
                 )
               ),
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -270,7 +270,7 @@ ui <- dashboardPage(
                 box(
                   width = 12,
                   title = "Collision Year Line Graph",
-                  "Insert collision year line graph here"
+                  plotlyOutput(outputId = "ddsb_all_year_plot")
                 )
               ),
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -248,6 +248,13 @@ ui <- dashboardPage(
               title = "All Vehicle Collision",
 
               fluidRow(
+                infoBoxOutput(width = 3, outputId = "box_all_total_collision"),
+                infoBoxOutput(width = 3, outputId = "box_all_total_casualty"),
+                infoBoxOutput(width = 3, outputId = "box_all_serious_stat"),
+                infoBoxOutput(width = 3, outputId = "box_all_fatal_stat")
+              ),
+
+              fluidRow(
                 box(
                     width = 6,
                     title = "Collision Map",


### PR DESCRIPTION
# Summary

This adds the basic widgets for the **"All Vehicle Collision"** tab in district dashboard section, similar to #18 and #23.

# Changes

The changes made in this PR are:

1. Add 4 boxes on top of the dashboard to show major statistics from the datasets user have filtered. Current major statistics include 1. total number of collisions; 2. total number of casualties; 3. number of serious casualties and 4. number of fatal casualties.

    ![summary-stat](https://user-images.githubusercontent.com/29334677/144839549-b2305605-dc12-433a-a5a7-c4ee65f1dff2.png)


1. Add an interactive heatmap showing the number of collisions

    ![gridded-choropleth](https://user-images.githubusercontent.com/29334677/144839530-a61e3137-46f0-4a94-bc5d-6d8bd42c9c72.png)

1. Add bar charts that classify the collisions/casualties/vehicles according to different categorical variables

    ![ksi-stat](https://user-images.githubusercontent.com/29334677/144839565-e3211bd6-42f3-4838-8efa-5dd5bdcd2889.png)

1. Add a year-trend graph of the total number of collisions in the selected district

    ![year-trend](https://user-images.githubusercontent.com/29334677/144839580-f80c60f8-0e59-412e-95db-6722be20bca9.png)
***

# Check

- [x] The travis.ci and R CMD checks pass.

***

## Note

Refactoring could be considered after charts and maps from all 3 tabs (all collision/pedestrian collision/cycle collision) are finalised. The code for generating interactive charts are similar.
