### PR TITLE
Feat: Edit charts in the "collision with cycle" tab

### DIFF
--- a/inst/app/modules/district_dsb_cyc.R
+++ b/inst/app/modules/district_dsb_cyc.R
@@ -160,11 +160,13 @@ output$ddsb_cyc_vehicle_class_plot = renderPlotly({
 # Vehicle movement plot
 output$ddsb_cyc_vehicle_movement_plot = renderPlotly({
 
-  # count by Vehicle_Class
-  plot_data = count(ddsb_cyc_filtered_hk_vehicles(), Main_vehicle, name = "count") %>%
+  # count by vehicle movement
+  plot_data = ddsb_cyc_filtered_hk_vehicles() %>%
+    # remove vehicles that are pedal cycles
+    filter(Pedal_cycle != "Pedal Cycle") %>%
+    count(Main_vehicle, name = "count") %>%
     # reorder vehicle class in descending order
     mutate(Main_vehicle_order = reorder(Main_vehicle, count))
-
 
   plot_by_vehicle_movement = ggplot(plot_data, aes(x = Main_vehicle_order, y = count)) +
     geom_bar(stat = "identity", fill = CATEGORY_COLOR$vehicles) +

--- a/inst/app/modules/district_dsb_cyc.R
+++ b/inst/app/modules/district_dsb_cyc.R
@@ -185,6 +185,36 @@ output$ddsb_cyc_vehicle_movement_plot = renderPlotly({
   ggplotly(plot_by_vehicle_movement)
 })
 
+# Cyclist action plot
+output$ddsb_cyc_cyc_action_plot = renderPlotly({
+
+  # As cyclist are deemed drivers of pedal cycle,
+  # cyclist actions are referenced by vehicle movement in the hk_vehicles dataset
+  plot_data = ddsb_cyc_filtered_hk_vehicles() %>%
+    # only select vehicles that are pedal cycles
+    filter(Pedal_cycle == "Pedal Cycle") %>%
+    count(Main_vehicle, name = "count") %>%
+    # reorder in descending order
+    mutate(Main_vehicle_order = reorder(Main_vehicle, count))
+
+  plot_by_vehicle_movement = ggplot(plot_data, aes(x = Main_vehicle_order, y = count)) +
+    geom_bar(stat = "identity", fill = CATEGORY_COLOR$casualties) +
+    coord_flip() +
+    theme_minimal() +
+    theme(
+      panel.grid.major.y = element_blank(),
+      panel.grid.minor.y = element_blank(),
+      legend.position = "none"
+    ) +
+    labs(
+      x = "",
+      title = "Cyclist movement at accident"
+    )
+
+  ggplotly(plot_by_vehicle_movement)
+
+})
+
 # Road hierarchy plot
 output$ddsb_cyc_road_hierarchy_plot = renderPlotly({
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -391,7 +391,7 @@ ui <- dashboardPage(
                 ),
                 box(
                   width = 6,
-                  title = "Vehicle Movement Stats",
+                  title = "Vehicle Movement Stats (Excluding pedal cycles)",
                   plotlyOutput(outputId = "ddsb_cyc_vehicle_movement_plot")
                 )
               ),

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -400,7 +400,7 @@ ui <- dashboardPage(
                 box(
                   width = 6,
                   title = "Cyclist Action Stats",
-                  "Insert cyclist action stats here"
+                  plotlyOutput(outputId = "ddsb_cyc_cyc_action_plot")
                 ),
                 box(
                   width = 6,


### PR DESCRIPTION
# Summary

This branch refines the charts in the "collision with cycle" tab in the district dashboard.

# Changes

The changes made in this PR are:

1. Exclude vehicles that are pedal cycles in the *Vehicle Movement Stats* plot
1. Create the *cyclist action stats* plots, which is a bar chart showing movement of cyclists during the collision. (Intrinsically same as the *Vehicle Movement Stats* plot, yet ONLY include vehicles that the pedal cycles)

***

# Check

- [x] The travis.ci and R CMD checks pass.
