### PR TITLE
Feat: Show full name of districts in area filter

### DIFF
--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -41,6 +41,11 @@ hk_casualties <- fst::read_fst("./data/hk_casualties.fst")
 tmap_mode("view")
 tmap_options(basemaps = c("CartoDB.Positron", "Stamen.TonerLite", "OpenStreetMap"))
 
+# Constants ---------------------------------------------------------------
+
+DISTRICT_ABBR = c("CW", "WCH", "E", "S", "YTM", "SSP", "KC", "WTS", "KT", "TW", "TM", "YL", "N", "TP", "SK", "ST", "KTS", "I")
+DISTRICT_FULL_NAME = hkdatasets::hkdistrict_summary[["District_EN"]]
+
 # Color scheme ------------------------------------------------------------
 
 SEVERITY_COLOR = c(Fatal = "#230B4C", Serious = "#C03A51", Slight = "#F1701E")

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -210,7 +210,7 @@ ui <- dashboardPage(
             title = "Area Filter",
             selectInput(
               inputId = "ddsb_district_filter", label = "Select District",
-              choices = unique(hk_accidents$District_Council_District)
+              choices = setNames(DISTRICT_ABBR, DISTRICT_FULL_NAME)
             )
           ),
           box(


### PR DESCRIPTION
# Summary

This branch changes the choices (i.e. 18 districts) in the area filter dropdown menu from abbreviation to full name in the district dashboard.

# Changes

After the changes:

![show-full-name](https://user-images.githubusercontent.com/29334677/144894011-b1289d2a-d5b8-4040-b48c-cf7a9ea9332e.png)

Before the changes:

![abbr-name](https://user-images.githubusercontent.com/29334677/144894342-d3c3fd97-71bc-4d50-9ca5-57932ec52037.png)

***

# Check

- [x] The travis.ci and R CMD checks pass.



