### PR TITLE
Feat: Refine popups

### DIFF
--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -41,6 +41,11 @@ hk_casualties <- fst::read_fst("./data/hk_casualties.fst")
 tmap_mode("view")
 tmap_options(basemaps = c("CartoDB.Positron", "Stamen.TonerLite", "OpenStreetMap"))
 
+# Constants ---------------------------------------------------------------
+
+DISTRICT_ABBR = c("CW", "WCH", "E", "S", "YTM", "SSP", "KC", "WTS", "KT", "TW", "TM", "YL", "N", "TP", "SK", "ST", "KTS", "I")
+DISTRICT_FULL_NAME = hkdatasets::hkdistrict_summary[["District_EN"]]
+
 # Color scheme ------------------------------------------------------------
 
 SEVERITY_COLOR = c(Fatal = "#230B4C", Serious = "#C03A51", Slight = "#F1701E")

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -100,16 +100,26 @@ observe({
     "<h3>", filter_collision_data()$Severity, " Collision</h3>",
 
     # Accident serial number
-    tags$b("Serial number: "), tags$br(), filter_collision_data()$Serial_No_, tags$br(),
+    tags$b("Serial number: "), filter_collision_data()$Serial_No_, tags$br(),
 
     # Accident date and time
-    tags$b("Accident date: "), tags$br(), strftime(filter_collision_data()$Date_Time, "%d %b %Y %H:%M"), tags$br(),
+    tags$b("Accident date: "), strftime(filter_collision_data()$Date_Time, "%d %b %Y %H:%M"), tags$br(),
+
+    tags$br(),
+
+    # District
+    tags$b("District: "), filter_collision_data()$District_Council_District, tags$br(),
     # Street Name
     tags$b("Road name: "), filter_collision_data()$Street_Name, tags$br(),
     # Full address of collision location
     tags$b("Precise location: "), tags$br(), filter_collision_data()$Precise_Location, tags$br(),
-    # District
-    tags$b("District: "), tags$br(), filter_collision_data()$District_Council_District, tags$br(),
+
+    tags$br(),
+
+    # Collision type
+    tags$b("Collision type: "), tags$br(), filter_collision_data()$Type_of_Collision_with_cycle, tags$br(),
+
+    tags$br(),
 
     # Number of vehicles involved
     tags$b("Number of vehicles: "), filter_collision_data()$No_of_Vehicles_Involved, tags$br(),
@@ -133,7 +143,7 @@ observe({
     tags$b("Road structure: "), filter_collision_data()$Structure_Type, tags$br(),
     tags$b("Road hierarchy: "), filter_collision_data()$Road_Hierarchy
 
-    )
+  )
 
   leafletProxy(mapId = "main_map", data = filter_collision_data()) %>%
     clearMarkers() %>%

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -5,13 +5,16 @@ hk_vehicles_involved <- hk_vehicles %>%
   summarize(vehicle_class_involved = paste(sort(unique(Vehicle_Class)), collapse = ", "))
 
 # Get casualty role involved in each accident to show in popup
-accidents_cas_type <- hk_casualties %>%
-  group_by(Serial_No_) %>%
-  summarise(
-    include_ped = any(Role_of_Casualty == "Pedestrian"),
-    include_pax = any(Role_of_Casualty == "Passenger"),
-    include_dvr = any(Role_of_Casualty == "Driver")
-  )
+casualty_role_n = hk_casualties %>% count(Serial_No_, Role_of_Casualty)
+
+accidents_cas_type <- casualty_role_n %>%
+  pivot_wider(
+    id_cols = Serial_No_,
+    names_from = Role_of_Casualty,
+    values_from = n, values_fill = 0
+  ) %>%
+  rename(cas_ped_n = Pedestrian, cas_pax_n = Passenger, cas_dvr_n = Driver)
+
 
 # Add date floored to first day of the month for easier month filter handling
 hk_accidents <- mutate(hk_accidents, year_month = floor_date_to_month(Date_Time))

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -142,7 +142,7 @@ observe({
     tags$br(),
     tags$br(),
 
-    tags$b("Within 70 m of junctions? "), filter_collision_data()$Within_70m, tags$br(),
+    tags$b("Within 70 m of junctions? "), ifelse(filter_collision_data()$Within_70m, "Yes", "No"), tags$br(),
     tags$b("Road structure: "), filter_collision_data()$Structure_Type, tags$br(),
     tags$b("Road hierarchy: "), filter_collision_data()$Road_Hierarchy
 

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -111,7 +111,7 @@ observe({
     tags$br(),
 
     # District
-    tags$b("District: "), filter_collision_data()$District_Council_District, tags$br(),
+    tags$b("District: "), filter_collision_data()$DC_full_name, tags$br(),
     # Street Name
     tags$b("Road name: "), filter_collision_data()$Street_Name, tags$br(),
     # Full address of collision location

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -108,8 +108,13 @@ observe({
     tags$b("Precise location: "), tags$br(), "TODO", tags$br(),
     # District
     tags$b("District: "), tags$br(), filter_collision_data()$District_Council_District, tags$br(),
+
+    # Number of vehicles involved
+    tags$b("Number of vehicles: "), filter_collision_data()$No_of_Vehicles_Involved, tags$br(),
     # Involved vehicle class
-    tags$b("Involved vehicle classes: "), tags$br(), filter_collision_data()$vehicle_class_involved, tags$br(),
+    tags$b("Involved vehicle classes: "), filter_collision_data()$vehicle_class_involved, tags$br(),
+
+    tags$br(),
 
     # Number of injuries
     tags$b("Number of casualties: "), filter_collision_data()$No_of_Casualties_Injured, tags$br(),

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -108,15 +108,20 @@ observe({
     tags$b("Precise location: "), tags$br(), "TODO", tags$br(),
     # District
     tags$b("District: "), tags$br(), filter_collision_data()$District_Council_District, tags$br(),
-    # Number of injuries
-    tags$b("Number of casualties: "), tags$br(), filter_collision_data()$No_of_Casualties_Injured, tags$br(),
     # Involved vehicle class
     tags$b("Involved vehicle classes: "), tags$br(), filter_collision_data()$vehicle_class_involved, tags$br(),
-    # Involved casualty
-    tags$b("Involved casualty role: "), tags$br(),
-    tags$b("Pedestrian: "), filter_collision_data()$include_ped, tags$br(),
-    tags$b("Passenger: "), filter_collision_data()$include_pax, tags$br(),
-    tags$b("Driver: "), filter_collision_data()$include_dvr
+
+    # Number of injuries
+    tags$b("Number of casualties: "), filter_collision_data()$No_of_Casualties_Injured, tags$br(),
+    # Involved casualty breakdown
+    "(",
+    filter_collision_data()$cas_dvr_n, " driver(s), ",
+    filter_collision_data()$cas_pax_n, " passenger(s), ",
+    filter_collision_data()$cas_ped_n, " pedestrian(s))",
+
+    tags$br(),
+    tags$br()
+
     )
 
   leafletProxy(mapId = "main_map", data = filter_collision_data()) %>%

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -105,7 +105,7 @@ observe({
     # Accident date and time
     tags$b("Accident date: "), tags$br(), strftime(filter_collision_data()$Date_Time, "%d %b %Y %H:%M"), tags$br(),
     # Full address of collision location
-    tags$b("Precise location: "), tags$br(), "TODO", tags$br(),
+    tags$b("Precise location: "), tags$br(), filter_collision_data()$Precise_Location, tags$br(),
     # District
     tags$b("District: "), tags$br(), filter_collision_data()$District_Council_District, tags$br(),
 

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -104,6 +104,8 @@ observe({
 
     # Accident date and time
     tags$b("Accident date: "), tags$br(), strftime(filter_collision_data()$Date_Time, "%d %b %Y %H:%M"), tags$br(),
+    # Street Name
+    tags$b("Road name: "), filter_collision_data()$Street_Name, tags$br(),
     # Full address of collision location
     tags$b("Precise location: "), tags$br(), filter_collision_data()$Precise_Location, tags$br(),
     # District

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -21,7 +21,10 @@ hk_accidents <- mutate(hk_accidents, year_month = floor_date_to_month(Date_Time)
 
 hk_accidents_join <- hk_accidents %>%
   left_join(accidents_cas_type, by = "Serial_No_") %>%
-  left_join(hk_vehicles_involved, by = "Serial_No_")
+  left_join(hk_vehicles_involved, by = "Serial_No_") %>%
+  # Show full name of district in popup of maps
+  left_join(data.frame(DC_Abbr = DISTRICT_ABBR, DC_full_name = DISTRICT_FULL_NAME),
+            by = c("District_Council_District" = "DC_Abbr"))
 
 hk_accidents_valid <- filter(hk_accidents_join, !is.na(latitude) & !is.na(longitude))
 

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -125,7 +125,11 @@ observe({
     filter_collision_data()$cas_ped_n, " pedestrian(s))",
 
     tags$br(),
-    tags$br()
+    tags$br(),
+
+    tags$b("Within 70 m of junctions? "), filter_collision_data()$Within_70m, tags$br(),
+    tags$b("Road structure: "), filter_collision_data()$Structure_Type, tags$br(),
+    tags$b("Road hierarchy: "), filter_collision_data()$Road_Hierarchy
 
     )
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -210,7 +210,7 @@ ui <- dashboardPage(
             title = "Area Filter",
             selectInput(
               inputId = "ddsb_district_filter", label = "Select District",
-              choices = unique(hk_accidents$District_Council_District)
+              choices = setNames(DISTRICT_ABBR, DISTRICT_FULL_NAME)
             )
           ),
           box(


### PR DESCRIPTION
# Summary

This branch adds new information and rearranges the order of details shown in the popup of the collision location map.

# Changes

The changes made in this PR are:

1. Add the following new information in the popup:
    - Street name (`Street_Name`)
    - Precision location (`Precise_Location`)
    - Collision type (`Type_of_Collision_with_cycle`)
    - Number of casualties (`No_of_Casualties_Injured`) with detailed breakdown
    - Within 70 m of junctions (`Within_70m`)
    - Road structure (`Structure_Type`)
    - Road hierarchy (`Road_Hierarchy`)
2. Changes the displayed district from abbreviation to the full name (`DC_full_name`) (e.g. "WC" -> "Wan Chai")
3. Rearrange the order of information shown
    - Basic identifier -> Location of collision -> Type of collision -> Involved vehicles -> Involved casualties -> Road characteristics/nature where collision happened
4. Misc paragraph/line formattings

<img width="475" alt="edited-popup" src="https://user-images.githubusercontent.com/29334677/145056910-83f1b66d-5a34-410c-91af-64d9490f7a44.png">

***

# Check
- [x] The collision map shows.
- [x] The popup displays correctly.
- [x] The travis.ci and R CMD checks pass.

***

## Note

In future, the bottom of each popup should provide a link to the webpage showing the full details of that collision.
