### PR TITLE
Feat: Use donut chart to show collisions by severity

### DIFF
--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -49,6 +49,7 @@ DISTRICT_FULL_NAME = hkdatasets::hkdistrict_summary[["District_EN"]]
 # Color scheme ------------------------------------------------------------
 
 SEVERITY_COLOR = c(Fatal = "#230B4C", Serious = "#C03A51", Slight = "#F1701E")
+SEVERITY_COLOR_DESAT = c(Fatal = "#251541", Serious = "#bb3e53", Slight = "#ffa500")
 CATEGORY_COLOR = setNames(as.list(c("#67B7DC", "#A367DC", "#FFAE12")), c("accidents", "casualties", "vehicles"))
 
 # Custom misc functions ---------------------------------------------------

--- a/inst/app/modules/district_dsb_all.R
+++ b/inst/app/modules/district_dsb_all.R
@@ -69,6 +69,32 @@ count_collisions_in_grid = function(point_data, grid_size = c(150, 150)) {
   area_grid_count
 }
 
+# Generate a donut chart of collisions by severity, with input_data in format of hk_accidents
+plot_severity_chart = function(input_data) {
+
+  # count by severity
+  plot_data = count(input_data, Severity, name = "count", na.rm = TRUE)
+
+  # ring chart is not available for ggplotly
+  plot_data %>%
+    plot_ly(
+      labels = ~ Severity, values = ~ count,
+      textinfo = "label+percent",
+      hovertemplate = paste0(
+        "<b>%{label}</b>", "<br><br>",
+        "No. of collisions: %{value:,}", "<br>",
+        "% of total: %{percent}",
+        # Remove `trace 0` text
+        # https://community.plotly.com/t/remove-trace-0-next-to-hover/33731
+        "<extra></extra>"),
+      marker = list(colors = SEVERITY_COLOR_DESAT),
+      # layouts
+      showlegend = F
+    ) %>%
+    add_pie(hole = 0.45) %>%
+    # align title to left
+    layout(title = list(text = "Selected collisions by severity", x = .05))
+}
 
 # Outputs ----------------------------------
 

--- a/inst/app/modules/district_dsb_all.R
+++ b/inst/app/modules/district_dsb_all.R
@@ -171,25 +171,8 @@ output$ddsb_all_collision_heatmap = renderTmap({
 # Collision number by severity
 output$ddsb_all_ksi_plot = renderPlotly({
 
-  # count by severity
-  plot_data = count(ddsb_filtered_hk_accidents(), Severity, name = "count", na.rm = TRUE)
+  plot_severity_chart(ddsb_filtered_hk_accidents())
 
-  plot_by_severity = ggplot(plot_data, aes(x = Severity, y = count, fill = Severity)) +
-    geom_bar(stat = "identity") +
-    coord_flip() +
-    scale_fill_manual(values = SEVERITY_COLOR) +
-    theme_minimal() +
-    theme(
-      panel.grid.major.y = element_blank(),
-      panel.grid.minor.y = element_blank(),
-      legend.position = "none"
-    ) +
-    labs(
-      x = "",
-      title = "Collisions by Severity"
-    )
-
-  ggplotly(plot_by_severity)
 })
 
 # Collision by year plot

--- a/inst/app/modules/district_dsb_cyc.R
+++ b/inst/app/modules/district_dsb_cyc.R
@@ -110,25 +110,8 @@ output$ddsb_cyc_collision_heatmap = renderTmap({
 # Collision number by severity
 output$ddsb_cyc_ksi_plot = renderPlotly({
 
-  # count by severity
-  plot_data = count(ddsb_cyc_filtered_hk_accidents(), Severity, name = "count", na.rm = TRUE)
+  plot_severity_chart(ddsb_cyc_filtered_hk_accidents())
 
-  plot_by_severity = ggplot(plot_data, aes(x = Severity, y = count, fill = Severity)) +
-    geom_bar(stat = "identity") +
-    coord_flip() +
-    scale_fill_manual(values = SEVERITY_COLOR) +
-    theme_minimal() +
-    theme(
-      panel.grid.major.y = element_blank(),
-      panel.grid.minor.y = element_blank(),
-      legend.position = "none"
-    ) +
-    labs(
-      x = "",
-      title = "Collisions by Severity"
-    )
-
-  ggplotly(plot_by_severity)
 })
 
 # Vehicle Class plot

--- a/inst/app/modules/district_dsb_ped.R
+++ b/inst/app/modules/district_dsb_ped.R
@@ -104,25 +104,8 @@ output$ddsb_ped_collision_heatmap = renderTmap({
 # Collision number by severity
 output$ddsb_ped_ksi_plot = renderPlotly({
 
-  # count by severity
-  plot_data = count(ddsb_ped_filtered_hk_accidents(), Severity, name = "count", na.rm = TRUE)
+  plot_severity_chart(ddsb_ped_filtered_hk_accidents())
 
-  plot_by_severity = ggplot(plot_data, aes(x = Severity, y = count, fill = Severity)) +
-    geom_bar(stat = "identity") +
-    coord_flip() +
-    scale_fill_manual(values = SEVERITY_COLOR) +
-    theme_minimal() +
-    theme(
-      panel.grid.major.y = element_blank(),
-      panel.grid.minor.y = element_blank(),
-      legend.position = "none"
-    ) +
-    labs(
-      x = "",
-      title = "Collisions by Severity"
-    )
-
-  ggplotly(plot_by_severity)
 })
 
 # Vehicle Class plot


### PR DESCRIPTION
# Summary

This branch changes the collision by severity charts in the district dashboard from bar chart to donut chart.

# Changes

The changes made in this PR are:

1. Centralise the process of creating *collision by severity* chart into a single function (`plot_severity_chart()`), with the filtered data as input
2. Use donut chart instead of bar chart to show the distribution of collision severity

<img width="480" alt="donut-chart-severity" src="https://user-images.githubusercontent.com/29334677/145162203-50722c6c-2574-466b-9c51-011083abc191.png">

***

# Check

- [ ] The travis.ci and R CMD checks pass.

***

## Note

IMO donut chart is preferred over bar chart for visualising by-severity data because:

1. Avoid repetition and differentiate between other charts in dashboard (which are mostly bar charts)
2. There are only 3 categories (Slight, Serious, Fatal) that will not make the donut chart split into too many "crumbles" and hard to read the number of each category.
