### PR TITLE
Feat: Change color scheme of collision map

### DIFF
--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -48,8 +48,11 @@ DISTRICT_FULL_NAME = hkdatasets::hkdistrict_summary[["District_EN"]]
 
 # Color scheme ------------------------------------------------------------
 
-SEVERITY_COLOR = c(Fatal = "#230B4C", Serious = "#C03A51", Slight = "#F1701E")
+SEVERITY_COLOR = c(Fatal = "#FF4039", Serious = "#FFB43F", Slight = "#FFE91D")
 CATEGORY_COLOR = setNames(as.list(c("#67B7DC", "#A367DC", "#FFAE12")), c("accidents", "casualties", "vehicles"))
+
+# Fill color palette according to the severity of the accident
+fill_palette = leaflet::colorFactor(palette = c("#FF4039", "#FFB43F", "#FFE91D"), domain = c("Fatal", "Serious", "Slight"))
 
 # Custom misc functions ---------------------------------------------------
 

--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -39,7 +39,7 @@ hk_casualties <- fst::read_fst("./data/hk_casualties.fst")
 # interactive thematic map mode option ------------------------------------
 
 tmap_mode("view")
-tmap_options(basemaps = c("CartoDB.Positron", "Stamen.TonerLite", "OpenStreetMap"))
+tmap_options(basemaps = c("Stamen.TonerLite", "CartoDB.Positron", "OpenStreetMap"))
 
 # Constants ---------------------------------------------------------------
 

--- a/inst/app/modules/district_dsb_all.R
+++ b/inst/app/modules/district_dsb_all.R
@@ -128,7 +128,7 @@ output$ddsb_all_collision_heatmap = renderTmap({
   tm_shape(all_grid_count()) +
     tm_fill(
       col = "n_colli",
-      palette = "YlOrRd",
+      palette = "Purples",
       n = 10,
       style = "cont",
       title = "Number of collisions",
@@ -138,7 +138,7 @@ output$ddsb_all_collision_heatmap = renderTmap({
       # disable popups
       popup.vars = FALSE,
     ) +
-    tm_borders(col = "white", lwd = 0.7)
+    tm_borders(col = "#232323", lwd = 0.7)
 
 })
 

--- a/inst/app/modules/district_dsb_cyc.R
+++ b/inst/app/modules/district_dsb_cyc.R
@@ -93,7 +93,7 @@ output$ddsb_cyc_collision_heatmap = renderTmap({
   tm_shape(cyc_grid_count()) +
     tm_fill(
       col = "n_colli",
-      palette = "YlOrRd",
+      palette = "Purples",
       n = 10,
       style = "cont",
       title = "Number of collisions",
@@ -103,7 +103,7 @@ output$ddsb_cyc_collision_heatmap = renderTmap({
       # disable popups
       popup.vars = FALSE,
     ) +
-    tm_borders(col = "white", lwd = 0.7)
+    tm_borders(col = "#232323", lwd = 0.7)
 
 })
 

--- a/inst/app/modules/district_dsb_ped.R
+++ b/inst/app/modules/district_dsb_ped.R
@@ -87,7 +87,7 @@ output$ddsb_ped_collision_heatmap = renderTmap({
   tm_shape(ped_grid_count()) +
     tm_fill(
       col = "n_colli",
-      palette = "YlOrRd",
+      palette = "Purples",
       n = 10,
       style = "cont",
       title = "Number of collisions",
@@ -97,7 +97,7 @@ output$ddsb_ped_collision_heatmap = renderTmap({
       # disable popups
       popup.vars = FALSE,
     ) +
-    tm_borders(col = "white", lwd = 0.7)
+    tm_borders(col = "#232323", lwd = 0.7)
 
 })
 

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -149,9 +149,9 @@ observe({
     clearMarkerClusters() %>%
     addCircleMarkers(
       # fixed point size symbol
-      radius = 7.5,
-      color = "#FFFFFF", weight = 1, opacity = .75,
-      fillColor = ~ fill_palette(Severity), fillOpacity = .75,
+      radius = 6,
+      color = "#0d0d0d", weight = 2, opacity = .9,
+      fillColor = ~ fill_palette(Severity), fillOpacity = .9,
       popup = popup_template,
       clusterOptions = markerClusterOptions(
         disableClusteringAtZoom = 16

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -83,10 +83,6 @@ filter_collision_data <- reactive({
   data_filtered
 })
 
-# Fill color palette according to the severity of the accident
-fill_palette <- colorFactor(palette = c("#230B4C", "#C03A51", "#F1701E"), domain = c("Fatal", "Serious", "Slight"))
-
-
 observe({
   # Template for popup, with summary of incidents
   popup_template = paste(

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -39,7 +39,7 @@ output$main_map <- renderLeaflet({
     addSearchOSM(options = searchOptions(hideMarkerOnCollapse = TRUE))
 
   # Subset basemap providers to be used for the map
-  SELECTED_BASEMAPS <- leaflet::providers[c("CartoDB.Positron", "Stamen.TonerLite", "OpenStreetMap")]
+  SELECTED_BASEMAPS <- leaflet::providers[c("Stamen.TonerLite", "CartoDB.Positron", "OpenStreetMap")]
 
   # Add the basemap tiles in background
   # http://rstudio.github.io/leaflet/morefeatures.html

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -149,9 +149,10 @@ ui <- dashboardPage(
 
               checkboxGroupButtons(
                 inputId = "severity_filter", label = "Collision severity",
-                choices = c(`Fatal <i style="color:#230B4C;" class="fas fa-skull-crossbones"></i>` = "Fatal",
-                            `Serious <i style="color:#C03A51;"class="fas fa-procedures"></i>` = "Serious",
-                            `Slight <i style="color:#F1701E;" class="fas fa-user-injured"></i>` = "Slight"),
+                # TODO: use sprintf and global SEVERITY_COLOR constant for mapping icon color
+                choices = c(`Fatal <i style="color:#FF4039;" class="fas fa-skull-crossbones"></i>` = "Fatal",
+                            `Serious <i style="color:#FFB43F;"class="fas fa-procedures"></i>` = "Serious",
+                            `Slight <i style="color:#FFE91D;" class="fas fa-user-injured"></i>` = "Slight"),
                 selected = unique(hk_accidents$Severity),
                 direction = "vertical",
                 justified = TRUE,

--- a/inst/app/www/styles.css
+++ b/inst/app/www/styles.css
@@ -13,26 +13,32 @@
 /* https://www.mapsmarker.com/kb/user-guide/how-to-change-the-color-of-marker-clusters/ */
 
 .marker-cluster-small {
-	background-color: rgba(170, 170, 170, 0.6) !important;
+  color: #FFFFFF !important;
+	background-color: rgba(34, 34, 34, 0.6) !important;
 }
 
 .marker-cluster-small div {
-	background-color: rgba(170, 170, 170, 0.6) !important;
+  color: #FFFFFF !important;
+	background-color: rgba(34, 34, 34, 0.6) !important;
 }
 
 .marker-cluster-medium {
-	background-color: rgba(170, 170, 170, 0.6) !important;
+  color: #FFFFFF !important;
+	background-color: rgba(34, 34, 34, 0.6) !important;
 }
 
 .marker-cluster-medium div {
-	background-color: rgba(170, 170, 170, 0.6) !important;
+  color: #FFFFFF !important;
+	background-color: rgba(34, 34, 34, 0.6) !important;
 }
 
 .marker-cluster-large {
-	background-color: rgba(170, 170, 170, 0.6) !important;
+  color: #FFFFFF !important;
+	background-color: rgba(34, 34, 34, 0.6) !important;
 }
 
 .marker-cluster-large div {
-	background-color: rgba(170, 170, 170, 0.6) !important;
+  color: #FFFFFF !important;
+	background-color: rgba(34, 34, 34, 0.6) !important;
 }
 


### PR DESCRIPTION
# Summary

This branch refines the uses of colors in the maps.

# Changes

The changes made in this PR are:

1. Change the representative color scheme of collision severity to the following:
    - Fatal: "#FF4039"
    - Serious: "#FFB43F"
    - Slight: "#FFE91D"
1. Change the default basemap to `"Stamen.TonerLite"`, a greyscale basemap theme to fit the overall UI
1. Refine of the cluster marker of the collision map to darker grey with white text
1. Change the color ramp of the gridded choropleth of collision in district dashboard to purple

![refined-collision-map](https://user-images.githubusercontent.com/29334677/146831842-196a4217-1f75-4278-a90b-03a631e532e8.png)

![refined-district-gridded-chorolpeth-map](https://user-images.githubusercontent.com/29334677/146831891-6c7f5651-a079-4e19-a05f-cf6019c4f348.png)


***

# Check

- [ ] The travis.ci and R CMD checks pass.
