### PR TITLE
Chore: Remove old testing code

### DIFF
--- a/inst/app/modules/plotly_testvisual.R
+++ b/inst/app/modules/plotly_testvisual.R
@@ -1,7 +1,0 @@
-output$plotly_testvisual = renderPlotly(
-  {
-    hk_accidents %>%
-      ggplot(aes(x = Type_of_Collision)) +
-      geom_histogram(stat = "count")
-  }
-)

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -20,10 +20,6 @@ server <- function(input, output, session) {
   source(file = "modules/main_map.R", local = TRUE)
 
 
-  # RenderPlot: Districts ---------------------------------------------------
-  source(file = "modules/plotly_testvisual.R", local = TRUE)
-
-
   # ----- TAB: Dashboard ----- #
   source(file = "modules/district_dsb_all.R", local = TRUE)
   source(file = "modules/district_dsb_ped.R", local = TRUE)

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -181,22 +181,6 @@ ui <- dashboardPage(
                 style = "font-size: 20px;text-align:center;"),
             )
           )
-        ),
-
-        fluidRow(
-          box(
-            width = 4,
-            title = "Location Filter",
-            "Insert location filter here"
-          )
-        ),
-        fluidRow(
-          plotlyOutput(outputId = "plotly_testvisual"),
-          box(
-            width = 4,
-            title = "Stats & Info",
-            "Insert data here"
-          )
         )
       ),
 


### PR DESCRIPTION
# Summary

This branch remove old skeleton code used for testing the UI layout of the collision map tab.

Removed UI components:

![obsolete-ui](https://user-images.githubusercontent.com/29334677/146978131-e290169e-a697-4f64-9dff-61ec3dbb11c3.png)

***

# Check

- [x] The travis.ci and R CMD checks pass.

