### PR TITLE
Feat: Add district filter

### DIFF
--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -71,6 +71,8 @@ filter_collision_data <- reactive({
 
   data_filtered = filter(data_filtered, Severity %in% input$severity_filter)
 
+  data_filtered = filter(data_filtered, District_Council_District %in% input$district_filter)
+
   # Get the serial numbers (in vector form) where vehicles involved includes users' selected vehicle class
   accient_w_selected_veh <- filter(hk_vehicles, Vehicle_Class %in% input$vehicle_class_filter)
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -135,6 +135,14 @@ ui <- dashboardPage(
 
               h2("Filter Panel"),
 
+              selectizeInput(
+                inputId = "district_filter",
+                label = "District(s):",
+                choices = setNames(DISTRICT_ABBR, DISTRICT_FULL_NAME),
+                selected = "KC",
+                options = list(maxItems = 3, placeholder = 'Select districts (3 maximum)')
+              ),
+
               airDatepickerInput("start_month",
                                  label = "From",
                                  value = "2016-05-01",

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -150,7 +150,8 @@ ui <- dashboardPage(
                                  max = as.Date(max(hk_accidents$Date_Time), tz = "Asia/Hong_Kong"),
                                  view = "months",
                                  minView = "months",
-                                 dateFormat = "MM yyyy"
+                                 dateFormat = "MM yyyy",
+                                 addon = "none"
               ),
 
               airDatepickerInput("end_month",
@@ -160,7 +161,8 @@ ui <- dashboardPage(
                                  max = as.Date(max(hk_accidents$Date_Time), tz = "Asia/Hong_Kong"),
                                  view = "months",
                                  minView = "months",
-                                 dateFormat = "MM yyyy"
+                                 dateFormat = "MM yyyy",
+                                 addon = "none"
               ),
 
               checkboxGroupButtons(


### PR DESCRIPTION
# Summary

This branch adds the district filter to the collision location map.

# Changes

The changes made in this PR are:

1. Add district filter on the collision location map

Leaflet will render all filtered points, even though the points may be outside the current mapview. Therefore, it takes high memory pressure to render a large number of points/markers on the map. This improve the efficiency and rendering time of the app.

2. Remove the calendar icons on the right-hand side of the date picker

The calendar icon will change the input filter to the current date by default (see `addon` argument for `shinyWidgets::airDatepickerInput`). This is not useful in our case, where collision data is a historical dataset.

***

# Check

- [ ] The travis.ci and R CMD checks pass.

***

## Note

The addition of the district filter is to cater for the memory limit of shinyapps.io (1 GB). Could remove the filter if the budget is enough to deploy the app on a server with a higher memory limit (e.g. 4 GB).
