### PR TITLE
Feat: Add collision type chart & fix vehicle-related stat in cyclist tab

### DIFF
--- a/inst/app/modules/district_dsb_all.R
+++ b/inst/app/modules/district_dsb_all.R
@@ -200,6 +200,33 @@ output$ddsb_all_year_plot = renderPlotly({
 
 })
 
+# Collision type plot
+output$ddsb_all_collision_type_plot = renderPlotly({
+
+  # count by pedestrian Action
+  plot_data = ddsb_filtered_hk_accidents() %>%
+    count(Type_of_Collision_with_cycle, name = "count") %>%
+    # reorder the drawing order from largest category
+    mutate(Collision_Type_order = reorder(Type_of_Collision_with_cycle, count))
+
+  plot_by_collision_type = ggplot(plot_data, aes(x = Collision_Type_order, y = count)) +
+    geom_bar(stat = "identity", fill = CATEGORY_COLOR$accidents) +
+    coord_flip() +
+    theme_minimal() +
+    theme(
+      panel.grid.major.y = element_blank(),
+      panel.grid.minor.y = element_blank(),
+      legend.position = "none",
+      plot.title.position = 'plot'
+    ) +
+    labs(
+      x = "",
+      title = "Collision type"
+    )
+
+  ggplotly(plot_by_collision_type)
+})
+
 # Road hierarchy plot
 output$ddsb_all_road_hierarchy_plot = renderPlotly({
 

--- a/inst/app/modules/district_dsb_all.R
+++ b/inst/app/modules/district_dsb_all.R
@@ -181,6 +181,9 @@ output$ddsb_all_year_plot = renderPlotly({
     annotate("rect", xmin = year_min, xmax = year_max, ymin = 0, ymax = max(plot_data$count), alpha = .2, fill = "red") +
     geom_line() +
     theme_minimal() +
+    theme(
+      panel.grid.major.x = element_blank()
+    ) +
     scale_y_continuous(limits = c(0, NA)) +
     labs(
       x = "Year",

--- a/inst/app/modules/district_dsb_all.R
+++ b/inst/app/modules/district_dsb_all.R
@@ -227,6 +227,34 @@ output$ddsb_all_collision_type_plot = renderPlotly({
   ggplotly(plot_by_collision_type)
 })
 
+# Vehicle Class plot
+output$ddsb_all_vehicle_class_plot = renderPlotly({
+
+  # count by Vehicle_Class
+  plot_data = count(ddsb_filtered_hk_vehicles(), Vehicle_Class, name = "count", na.rm = TRUE) %>%
+    # reorder vehicle class in descending order
+    mutate(Vehicle_Class_order = reorder(Vehicle_Class, count))
+
+
+  plot_by_vehicle_class = ggplot(plot_data, aes(x = Vehicle_Class_order, y = count)) +
+    geom_bar(stat = "identity", fill = CATEGORY_COLOR$vehicles) +
+    coord_flip() +
+    theme_minimal() +
+    theme(
+      panel.grid.major.y = element_blank(),
+      panel.grid.minor.y = element_blank(),
+      legend.position = "none"
+    ) +
+    labs(
+      x = "",
+      title = "Number of vehicles involved"
+    )
+
+  ggplotly(plot_by_vehicle_class)
+})
+
+
+
 # Road hierarchy plot
 output$ddsb_all_road_hierarchy_plot = renderPlotly({
 

--- a/inst/app/modules/district_dsb_cyc.R
+++ b/inst/app/modules/district_dsb_cyc.R
@@ -30,6 +30,18 @@ ddsb_cyc_filtered_hk_vehicles = reactive({
   filter(hk_vehicles, Serial_No_ %in% serial_no_filtered)
 })
 
+# Cycle-related vehicle collision, yet exclude cycle in vehicles
+ddsb_cyc_filtered_hk_vehicles_wo_cycle = reactive({
+
+  serial_no_filtered = ddsb_cyc_filtered_hk_accidents() %>%
+    filter(Type_of_Collision_with_cycle == "Vehicle collision with Pedal Cycle") %>%
+    pull(Serial_No_)
+
+  # exclude cycle when counting vehicle class
+  filter(hk_vehicles, Serial_No_ %in% serial_no_filtered & Vehicle_Class != "Bicycle")
+})
+
+
 cyc_grid_count = reactive({
   count_collisions_in_grid(ddsb_cyc_filtered_hk_accidents())
 })
@@ -135,7 +147,7 @@ output$ddsb_cyc_ksi_plot = renderPlotly({
 output$ddsb_cyc_vehicle_class_plot = renderPlotly({
 
   # count by Vehicle_Class
-  plot_data = count(ddsb_cyc_filtered_hk_vehicles(), Vehicle_Class, name = "count", na.rm = TRUE) %>%
+  plot_data = count(ddsb_cyc_filtered_hk_vehicles_wo_cycle(), Vehicle_Class, name = "count", na.rm = TRUE) %>%
     # reorder vehicle class in descending order
     mutate(Vehicle_Class_order = reorder(Vehicle_Class, count))
 
@@ -161,11 +173,7 @@ output$ddsb_cyc_vehicle_class_plot = renderPlotly({
 output$ddsb_cyc_vehicle_movement_plot = renderPlotly({
 
   # count by vehicle movement
-  plot_data = ddsb_cyc_filtered_hk_vehicles() %>%
-    # remove vehicles that are pedal cycles
-    filter(Pedal_cycle != "Pedal Cycle") %>%
-    count(Main_vehicle, name = "count") %>%
-    # reorder vehicle class in descending order
+  plot_data = count(ddsb_cyc_filtered_hk_vehicles_wo_cycle(), Main_vehicle, name = "count", na.rm = TRUE) %>%
     mutate(Main_vehicle_order = reorder(Main_vehicle, count))
 
   plot_by_vehicle_movement = ggplot(plot_data, aes(x = Main_vehicle_order, y = count)) +

--- a/inst/app/modules/district_dsb_cyc.R
+++ b/inst/app/modules/district_dsb_cyc.R
@@ -143,6 +143,33 @@ output$ddsb_cyc_ksi_plot = renderPlotly({
   ggplotly(plot_by_severity)
 })
 
+# Collision type plot
+output$ddsb_cyc_collision_type_plot = renderPlotly({
+
+  # count by pedestrian Action
+  plot_data = ddsb_cyc_filtered_hk_accidents() %>%
+    count(Type_of_Collision_with_cycle, name = "count") %>%
+    # reorder the drawing order from largest category
+    mutate(Collision_Type_order = reorder(Type_of_Collision_with_cycle, count))
+
+  plot_by_collision_type = ggplot(plot_data, aes(x = Collision_Type_order, y = count)) +
+    geom_bar(stat = "identity", fill = CATEGORY_COLOR$accidents) +
+    coord_flip() +
+    theme_minimal() +
+    theme(
+      panel.grid.major.y = element_blank(),
+      panel.grid.minor.y = element_blank(),
+      legend.position = "none",
+      plot.title.position = 'plot'
+    ) +
+    labs(
+      x = "",
+      title = "Collision type"
+    )
+
+  ggplotly(plot_by_collision_type)
+})
+
 # Vehicle Class plot
 output$ddsb_cyc_vehicle_class_plot = renderPlotly({
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -372,6 +372,14 @@ ui <- dashboardPage(
             fluidRow(
               box(
                 width = 6,
+                title = "Collision Type",
+                plotlyOutput(outputId = "ddsb_cyc_collision_type_plot")
+              )
+            ),
+
+            fluidRow(
+              box(
+                width = 6,
                 title = "Vehicle Class Stats (Only include collisions which vehicle collied with pedal cycle)",
                 plotlyOutput(outputId = "ddsb_cyc_vehicle_class_plot")
               ),

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -372,12 +372,12 @@ ui <- dashboardPage(
             fluidRow(
               box(
                 width = 6,
-                title = "Vehicle Class Stats",
+                title = "Vehicle Class Stats (Only include collisions which vehicle collied with pedal cycle)",
                 plotlyOutput(outputId = "ddsb_cyc_vehicle_class_plot")
               ),
               box(
                 width = 6,
-                title = "Vehicle Movement Stats (Excluding pedal cycles)",
+                title = "Vehicle Movement Stats (Only include collisions which vehicle collied with pedal cycle)",
                 plotlyOutput(outputId = "ddsb_cyc_vehicle_movement_plot")
               )
             ),

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -268,9 +268,14 @@ ui <- dashboardPage(
 
             fluidRow(
               box(
-                width = 12,
+                width = 6,
                 title = "Collision Year Line Graph",
                 plotlyOutput(outputId = "ddsb_all_year_plot")
+              ),
+              box(
+                width = 6,
+                title = "Collision Type",
+                plotlyOutput(outputId = "ddsb_all_collision_type_plot")
               )
             ),
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -283,8 +283,7 @@ ui <- dashboardPage(
               box(
                 width = 6,
                 title = "Vehicle Class Stats",
-                plotlyOutput(outputId = "ddsb_all_vehicle_class_plot"),
-                "Insert vehicle class stat graph here"
+                plotlyOutput(outputId = "ddsb_all_vehicle_class_plot")
               ),
               box(
                 width = 6,


### PR DESCRIPTION
# Summary

This branch add collision type chart & fix vehicle-related stat in cyclist tab.

# Changes

The changes made in this PR are:

1. Add **Collision Type** chart (`Type_of_collision_with_cycle` column in `hk_accidents` dataset) for all-collision and cycle-collision tab

    ![collision-type-all-collision-tab](https://user-images.githubusercontent.com/29334677/166334897-a1f03d5a-1dd5-4316-a9c6-b0bb4d646479.png)


1. Add **Vehicle Class** chart (`Vehicle_Class` column in `hk_vehicles` dataset) for all-collision tab

    ![vehicle-class-all-collision-tab](https://user-images.githubusercontent.com/29334677/166334869-42c81459-6022-453f-b6fe-eb6c8aabc4bd.png)


1. **Fix**: only include vehicles in collision type `Vehicle collision with Pedal Cycle` when computing statistics of vehicles in cyclist-collision tab. Add Explicit remark to remind that bicycle are excluded in vehicle-related stats.

    ![vehicle-stat-cyclist-tab](https://user-images.githubusercontent.com/29334677/166334960-4ecc8fb7-9d73-425d-81f5-c0937d711b3e.png)


***

# Check

- [ ] The travis.ci and R CMD checks pass.

