### PR TITLE
Feat: Add "Zoom to selected feature" button for hot zone table

### DIFF
--- a/inst/app/modules/gomap.js
+++ b/inst/app/modules/gomap.js
@@ -1,0 +1,16 @@
+// Zoom to the specified location on a leaflet map in shiny
+// adapted from https://github.com/rstudio/shiny-examples/blob/main/063-superzip-example/gomap.js
+
+// When locator icon in datatable is clicked, go to that spot on the map
+$(document).on("click", ".go-map", function(e) {
+  e.preventDefault();
+  $el = $(this);
+  var lat = $el.data("lat");
+  var lng = $el.data("lng");
+  // $($("#nav a")[0]).tab("show");
+  Shiny.onInputChange("goto", {
+    lat: lat,
+    lng: lng,
+    nonce: Math.random()
+  });
+});

--- a/inst/app/modules/hotzones.R
+++ b/inst/app/modules/hotzones.R
@@ -40,6 +40,21 @@ output$hotspots_map = renderTmap({
 
 })
 
+observe({
+  # escape initialise state
+  if (is.null(input$goto)) return()
+
+  isolate({
+    map = leafletProxy("hotspots_map")
+
+    lat = input$goto$lat
+    lng = input$goto$lng
+
+    setView(map, lng, lat, zoom = 17)
+  })
+})
+
+
 hotzone_out_df = hotzone_streets %>%
   st_centroid() %>%
   st_transform(crs = st_crs(4326)) %>%
@@ -56,10 +71,17 @@ hotzone_out_df = hotzone_streets %>%
   dplyr::relocate(Area_RK, zoom_in_map_link)
 
 output$hotspots_table = renderDataTable({
+
+  # `rownames` needs to be consistent with `DT::datatable` option
+  action = DT::dataTableAjax(session, hotzone_out_df, rownames = FALSE)
+
   datatable(
-    st_drop_geometry(hotzone_streets),
+    hotzone_out_df,
     colnames = TABLE_COLUMN_NAMES,
-    rownames = FALSE
+    rownames = FALSE,
+    options = list(ajax = list(url = action)),
+    # Render HTML tags inside table (e.g. fontawesome icons in <i> tags)
+    escape = FALSE
     ) %>%
     # Add in-cell bar chart for collision density
     formatStyle(

--- a/inst/app/modules/hotzones.R
+++ b/inst/app/modules/hotzones.R
@@ -9,7 +9,8 @@ TABLE_COLUMN_NAMES = c(
   "Rank" = "Area_RK",
   "Section Length (m)" = "Road_Length",
   "No. of collisions between 2015 - 2019" = "N_Colli",
-  "Collision Density (No. of collisions per km of road)" = "Colli_Density"
+  "Collision Density (No. of collisions per km of road)" = "Colli_Density",
+  "Zoom to the Zone" = "zoom_in_map_link"
 )
 
 

--- a/inst/app/modules/hotzones.R
+++ b/inst/app/modules/hotzones.R
@@ -40,6 +40,21 @@ output$hotspots_map = renderTmap({
 
 })
 
+hotzone_out_df = hotzone_streets %>%
+  st_centroid() %>%
+  st_transform(crs = st_crs(4326)) %>%
+  mutate(lng = sf::st_coordinates(.)[,1], lat = sf::st_coordinates(.)[,2]) %>%
+  # create the required data zooming into the feature with gomap.js
+  mutate(zoom_in_map_link =
+           paste('<a class="go-map" href=""',
+                 'data-lat="', lat, '" data-lng="', lng,
+                 '"><i class="fas fa-search-plus"></i></a>',
+                 sep="")
+         ) %>%
+  st_set_geometry(NULL) %>%
+  dplyr::select(-c(lat, lng)) %>%
+  dplyr::relocate(Area_RK, zoom_in_map_link)
+
 output$hotspots_table = renderDataTable({
   datatable(
     st_drop_geometry(hotzone_streets),

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -108,7 +108,8 @@ ui <- dashboardPage(
 
     # add custom css style for the data filter panel
     tags$head(
-      tags$link(rel = "stylesheet", type = "text/css", href = "styles.css")
+      tags$link(rel = "stylesheet", type = "text/css", href = "styles.css"),
+      includeScript("./modules/gomap.js")
     ),
 
     tabItems(


### PR DESCRIPTION
# Summary

This branch adds "Zoom to selected feature" buttons for the hot zone table.

# Changes

The changes made in this PR are:

1. Add a "Zoom to selected feature" button on each row in the hot zone table viewer. When the user clicks on the button, the interactive map will automatically zoom to the hot zone of that specific row.

https://user-images.githubusercontent.com/29334677/168443561-7da1d9ed-95e5-4d7c-8c62-5b69bcab8e42.mp4



***

# Check

- [x] The travis.ci and R CMD checks pass.

