### PR TITLE
Feat: Add glossary table

### DIFF
--- a/inst/app/data/terminology.csv
+++ b/inst/app/data/terminology.csv
@@ -1,0 +1,12 @@
+術語,Term,定義,Definition
+事故,Collision,一宗意外事故發生於本港道路上，涉及一輛或以上車輛，並已向警方備案，而在此意外事件中涉及傷亡者。,"An collision reported to the Police, involving personal injury occurring on roads in the Territory, in which one or more vehicles are involved."
+傷亡者,Casualty ,在一宗意外中導致受傷或死亡的人士，而在這事件中或涉及多於一位傷亡者。,A person killed or injured in an accident in which there may be more than one casualty.
+致命意外,Fatal Accident,在意外中有一位或多位人士於發生意外後三十日內死亡。,A fatal accident is where one or more persons dies within 30 days of the accident.
+嚴重意外,Serious Accident,在意外中有一位或多位受傷人士因意外而留醫超過十二小時。,One or more persons injured and detained in hospital for more than twelve hours.
+輕微意外,Slight Accident,在意外中只涉及一位或多位受傷人士，他們如需要留醫，均不超過十二小時。,"One or more persons injured and detention in hospital, if required, will not be more than twelve hours."
+死亡者,Killed Casualty,受害者在意外後三十日內持續受傷最後導致去世。,Sustained injury causing death within 30 days of the accident.
+重傷者,Serious Casualty,受傷人士入院後留醫超越十二小時視作嚴重受傷。受傷人士於意外後三十日以上才去世亦屬此項。 ,An injury for which a person is detained in hospital as an 'in-patient' for more than twelve hours. Injuries causing death 30 or more days after the accident is also included in this category.
+輕傷者,Slight Casualty,受傷人士屬輕微性如扭傷或割傷而非嚴重者，又如輕微休克而需在路旁照顧及不需要入院或只留院少於十二小時者。 ,"An injury of a minor character such as a sprain, bruise or cut not judged to be severe, or slight shock requiring roadside attention and detention in hospital is less than 12 hours, or not required."
+死亡或重傷者,Killed or Seriously Injured (KSI) Casualty,受傷人士屬死亡者或重傷者。,An injury belongs to killed casualty or serious casualty.
+道路使用者,Road users,行人和車輛使用者包括所有車內人士(如駕駛者和乘客，包括上落車而受傷的人士。) ,"Pedestrians and vehicle users which include all occupants (i.e. driver or rider and passengers, including persons injured while boarding or alighting from the vehicle)."
+牽涉車輛,Vehicle Involved,包括受傷的駕駛者或乘客所乘坐的車輛，或撞倒行人的車輛，或涉及該意外中的另一車輛受損毀或有車內人士受傷，或導致該意外發生的其他車輛。,"Vehicles whose drivers or passengers are injured, which hit a pedestrian, or which are hit by another vehicle."

--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -52,8 +52,10 @@ hk_casualties <- fst::read_fst("./data/hk_casualties.fst")
 
 hotzone_streets = read_sf("./data/hotzone_streets.gpkg")
 
-## Manipulated data, generated from `modules/manipulate_data.R`
+## Project info data
+terminology = read.csv("./data/terminology.csv")
 
+## Manipulated data, generated from `modules/manipulate_data.R`
 hk_accidents_valid_sf = read_sf("./data/data-manipulated/hk_accidents_valid_sf.gpkg")
 hotzone_out_df = fst::read_fst("./data/data-manipulated/hotzone_out_df.fst")
 

--- a/inst/app/modules/project_info.R
+++ b/inst/app/modules/project_info.R
@@ -1,6 +1,14 @@
 # Terminology table
 output$terminology_table = renderDataTable({
   datatable(
-    terminology
+    terminology,
+    rownames = FALSE,
+    # Show all rows in one single page
+    options = list(
+      # only show the filtering box (f) and the table (t)
+      dom = 'ft',
+      # Show all rows in one single page
+      pageLength = 100
+      )
     )
 })

--- a/inst/app/modules/project_info.R
+++ b/inst/app/modules/project_info.R
@@ -1,0 +1,6 @@
+# Terminology table
+output$terminology_table = renderDataTable({
+  datatable(
+    terminology
+    )
+})

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -41,5 +41,6 @@ server <- function(input, output, session) {
 
 
   # ----- TAB: Project Info ----- #
+  source(file = "modules/project_info.R", local = TRUE)
 
 }

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -484,6 +484,15 @@ ui <- dashboardPage(
         fluidRow(
           box(
             width = 12,
+            title = "Glossary of Terms",
+            p("The following terms are used in this website."),
+            dataTableOutput(outputId = "terminology_table")
+          )
+        ),
+
+        fluidRow(
+          box(
+            width = 12,
             hr(),
             paste("Hong Kong Traffic Injury Collision Database ver.", get_last_modified_date(getwd())),
             br(),

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -484,7 +484,9 @@ ui <- dashboardPage(
         fluidRow(
           box(
             width = 12,
-            title = "Glossary of Terms",
+            # Add icon inside heading
+            # https://community.rstudio.com/t/how-to-add-an-icon-in-shinydashboard-box-title/20650
+            title = span(icon("th-list"), "Glossary of Terms"),
             p("The following terms are used in this website."),
             dataTableOutput(outputId = "terminology_table")
           )


### PR DESCRIPTION
# Summary

This branch adds an interactive glossary table to the website project information tab.

# Changes

The changes made in this PR are:

1. Add a CSV file storing the glossary data (`terminology.csv`)
2. Create an interactive DT table for users to view and search for terms used throughout the website

![glossary-table](https://user-images.githubusercontent.com/29334677/183937091-4e2c0e78-67fb-4455-841b-bc5406ceae8c.png)


***

# Check

- [ ] The travis.ci and R CMD checks pass.

***

## Note

When terms are added in the future, they should be appended to the `terminology.csv` file.
