### PR TITLE
Refactor: Use environment variable to store access token

### DIFF
--- a/inst/app/modules/hotzones.R
+++ b/inst/app/modules/hotzones.R
@@ -1,7 +1,10 @@
 
 # Add tile from mapbox style
 # https://docs.mapbox.com/studio-manual/guides/publish-your-style/
-COLLISION_PTS_TILE_URL = "https://api.mapbox.com/styles/v1/khwong12/ckz18sv3a004415qrmcs9geal/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1Ijoia2h3b25nMTIiLCJhIjoiY2ptMGJqMHh2MGFzZjNsbXl2MjVuMGl1biJ9.N5P5k0byVnsWeBg6iLObww"
+COLLISION_PTS_TILE_URL = paste0(
+  "https://api.mapbox.com/styles/v1/khwong12/ckz18sv3a004415qrmcs9geal/tiles/256/{z}/{x}/{y}?access_token=",
+  Sys.getenv("MAPBOX_PUBLIC_TOKEN")
+  )
 
 TABLE_COLUMN_NAMES = c(
   "Hot Zone Name" = "Name",


### PR DESCRIPTION
# Summary

This branch stores Mapbox access token as an environment variable for accessing Mapbox services (currently tiles).

# Changes

The changes made in this PR are:

1. Remove the committed token (https://github.com/Hong-Kong-Districts-Info/hktrafficcollisions/pull/42/commits/9d24b193a28be1586500c2dfe509458766bfa7f2).
1. Create an environment variable `MAPBOX_PUBLIC_TOKEN` to store the Mapbox access token inside the `.Renviron` file.
1. Use `Sys.getenv("MAPBOX_PUBLIC_TOKEN")` to get the link of the pedestrian collision tile from Mapbox.

***

# Check

- [x] The old access token is removed.
- [x] The new access token is not publicly available.
- [x] The travis.ci and R CMD checks pass.

***

## Note

The new `.Renviron` file should

1. store in the root directory of Shiny application (`./inst/app/`)
3. publish to shinyapps.io server for deployment

See (https://stackoverflow.com/questions/39084284/how-to-pass-environment-variables-to-shinyapps) for further references.
