### PR TITLE
Feat: Refine icon shown in severity filter

### DIFF
--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -190,11 +190,16 @@ ui <- dashboardPage(
               checkboxGroupButtons(
                 inputId = "severity_filter", label = "Collision severity",
                 # TODO: use sprintf and global SEVERITY_COLOR constant for mapping icon color
-                choices = c(
-                  `<div style="display: flex;justify-content: center;align-items: center;"><span class="filter__circle-marker" style="background-color: #FF4039;"></span><span class="filter__text">Fatal</span></div>` = "Fatal",
-                  `<div style="display: flex;justify-content: center;align-items: center;"><span class="filter__circle-marker" style="background-color: #FFB43F;"></span><span class="filter__text">Serious</span></div>` = "Serious",
-                  `<div style="display: flex;justify-content: center;align-items: center;"><span class="filter__circle-marker" style="background-color: #FFE91D"></span><span class="filter__text">Slight</span></div>` = "Slight"
-                ),
+                choiceNames = c(
+                  '<div style="display: flex;justify-content: center;align-items: center;"><span class="filter__circle-marker" style="background-color: #FF4039;"></span><span class="filter__text">Fatal</span></div>',
+                  '<div style="display: flex;justify-content: center;align-items: center;"><span class="filter__circle-marker" style="background-color: #FFB43F;"></span><span class="filter__text">Serious</span></div>',
+                  '<div style="display: flex;justify-content: center;align-items: center;"><span class="filter__circle-marker" style="background-color: #FFE91D"></span><span class="filter__text">Slight</span></div>'
+                  ),
+                choiceValues = c(
+                  "Fatal",
+                  "Serious",
+                  "Slight"
+                  ),
                 selected = unique(hk_accidents$Severity),
                 direction = "vertical",
                 justified = TRUE

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -191,9 +191,9 @@ ui <- dashboardPage(
                 inputId = "severity_filter", label = "Collision severity",
                 # TODO: use sprintf and global SEVERITY_COLOR constant for mapping icon color
                 choices = c(
-                  `<div style="display: flex;justify-content: center;align-items: center;"><span class="dot" style="height: 14px;width: 14px;background-color: #FF4039;border-radius: 50%;border: 1.5px solid #0d0d0d;"></span><span style="color:black;padding-left:10px;"> Fatal</span></div>` = "Fatal",
-                  `<div style="display: flex;justify-content: center;align-items: center;"><span class="dot" style="height: 14px;width: 14px;background-color: #FFB43F;border-radius: 50%;border: 1.5px solid #0d0d0d;"></span><span style="color:black;padding-left:10px;"> Serious</span></div>` = "Serious",
-                  `<div style="display: flex;justify-content: center;align-items: center;"><span class="dot" style="height: 14px;width: 14px;background-color: #FFE91D;border-radius: 50%;border: 1.5px solid #0d0d0d;"></span><span style="color:black;padding-left:10px;"> Slight</span></div>` = "Slight"
+                  `<div style="display: flex;justify-content: center;align-items: center;"><span class="filter__circle-marker" style="background-color: #FF4039;"></span><span class="filter__text">Fatal</span></div>` = "Fatal",
+                  `<div style="display: flex;justify-content: center;align-items: center;"><span class="filter__circle-marker" style="background-color: #FFB43F;"></span><span class="filter__text">Serious</span></div>` = "Serious",
+                  `<div style="display: flex;justify-content: center;align-items: center;"><span class="filter__circle-marker" style="background-color: #FFE91D"></span><span class="filter__text">Slight</span></div>` = "Slight"
                 ),
                 selected = unique(hk_accidents$Severity),
                 direction = "vertical",

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -197,8 +197,7 @@ ui <- dashboardPage(
                 ),
                 selected = unique(hk_accidents$Severity),
                 direction = "vertical",
-                justified = TRUE,
-                checkIcon = list(yes = icon("ok", lib = "glyphicon"))
+                justified = TRUE
               ),
 
               collapsibleAwesomeCheckboxGroupInput(

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -190,9 +190,11 @@ ui <- dashboardPage(
               checkboxGroupButtons(
                 inputId = "severity_filter", label = "Collision severity",
                 # TODO: use sprintf and global SEVERITY_COLOR constant for mapping icon color
-                choices = c(`Fatal <i style="color:#FF4039;" class="fas fa-skull-crossbones"></i>` = "Fatal",
-                            `Serious <i style="color:#FFB43F;"class="fas fa-procedures"></i>` = "Serious",
-                            `Slight <i style="color:#FFE91D;" class="fas fa-user-injured"></i>` = "Slight"),
+                choices = c(
+                  `<div style="display: flex;justify-content: center;align-items: center;"><span class="dot" style="height: 14px;width: 14px;background-color: #FF4039;border-radius: 50%;border: 1.5px solid #0d0d0d;"></span><span style="color:black;padding-left:10px;"> Fatal</span></div>` = "Fatal",
+                  `<div style="display: flex;justify-content: center;align-items: center;"><span class="dot" style="height: 14px;width: 14px;background-color: #FFB43F;border-radius: 50%;border: 1.5px solid #0d0d0d;"></span><span style="color:black;padding-left:10px;"> Serious</span></div>` = "Serious",
+                  `<div style="display: flex;justify-content: center;align-items: center;"><span class="dot" style="height: 14px;width: 14px;background-color: #FFE91D;border-radius: 50%;border: 1.5px solid #0d0d0d;"></span><span style="color:black;padding-left:10px;"> Slight</span></div>` = "Slight"
+                ),
                 selected = unique(hk_accidents$Severity),
                 direction = "vertical",
                 justified = TRUE,

--- a/inst/app/www/styles.css
+++ b/inst/app/www/styles.css
@@ -96,7 +96,24 @@
 	background-color: rgba(34, 34, 34, 0.6) !important;
 }
 
-/* Widgets */
+
+
+
+/*
+  Widgets
+*/
+
+.filter__circle-marker {
+  height: 14px;
+  width: 14px;
+  border-radius: 50%;
+  border: 1.5px solid #0d0d0d;
+}
+
+.filter__text {
+  color:black;
+  padding-left:10px;
+}
 
 /* Hide / Show all button in collapsible group checkbox */
 .bttn-minimal.bttn-primary {


### PR DESCRIPTION
# Summary

This branch changes the icon used in the severity filter (closes #59).

# Changes

The changes made in this PR are:

1. Change the symbols used in the severity filter in the collision location map from icons to circle markers (same layout used for the collision map)
1. Create two HTML classes (`filter__circle-marker` and `filter__text`) for adjusting UI layout of the filter in the external CSS file (`styles.css`)
1. Remove tick icon when that severity category is selected

### Before

![before-severity-filter](https://user-images.githubusercontent.com/29334677/184686802-3b275e2e-2183-49f3-9dfa-7b2eba95b59c.png)


### After

![after-severity-filter](https://user-images.githubusercontent.com/29334677/184686760-4f31bd09-77cb-4a18-af90-32b3ebee0bdb.png)


***

# Check

- [ ] The travis.ci and R CMD checks pass.

