### PR TITLE
Fix: Use CartoDB Positron as default basemap

### DIFF
--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -61,8 +61,11 @@ hotzone_out_df = fst::read_fst("./data/data-manipulated/hotzone_out_df.fst")
 
 # interactive thematic map mode option ------------------------------------
 
+# Subset basemap providers to be used for interactive maps
+SELECTED_BASEMAPS = c("CartoDB.Positron", "OpenStreetMap", "Stamen.TonerLite")
+
 tmap_mode("view")
-tmap_options(basemaps = c("CartoDB.Positron", "OpenStreetMap", "Stamen.TonerLite"))
+tmap_options(basemaps = SELECTED_BASEMAPS)
 
 # Constants ---------------------------------------------------------------
 

--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -62,7 +62,7 @@ hotzone_out_df = fst::read_fst("./data/data-manipulated/hotzone_out_df.fst")
 # interactive thematic map mode option ------------------------------------
 
 tmap_mode("view")
-tmap_options(basemaps = c("Stamen.TonerLite", "CartoDB.Positron", "OpenStreetMap"))
+tmap_options(basemaps = c("CartoDB.Positron", "OpenStreetMap", "Stamen.TonerLite"))
 
 # Constants ---------------------------------------------------------------
 

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -4,19 +4,19 @@ output$main_map <- renderLeaflet({
     # Add geocoder map widget
     addSearchOSM(options = searchOptions(hideMarkerOnCollapse = TRUE))
 
-  # Subset basemap providers to be used for the map
-  SELECTED_BASEMAPS <- leaflet::providers[c("CartoDB.Positron", "OpenStreetMap", "Stamen.TonerLite")]
+  # addLayersControl and addProviderTiles needs to refer to the leaflet::providers list instead of vector
+  SELECTED_BASEMAPS_LIST <- leaflet::providers[SELECTED_BASEMAPS]
 
   # Add the basemap tiles in background
   # http://rstudio.github.io/leaflet/morefeatures.html
-  for (provider in SELECTED_BASEMAPS) {
+  for (provider in SELECTED_BASEMAPS_LIST) {
     overview_map <- addProviderTiles(overview_map, provider, group = provider)
   }
 
   # Add change basemap widget
   addLayersControl(
     overview_map,
-    baseGroups = names(SELECTED_BASEMAPS),
+    baseGroups = names(SELECTED_BASEMAPS_LIST),
     options = layersControlOptions(collapsed = TRUE),
     position = "topleft"
     )

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -5,7 +5,7 @@ output$main_map <- renderLeaflet({
     addSearchOSM(options = searchOptions(hideMarkerOnCollapse = TRUE))
 
   # Subset basemap providers to be used for the map
-  SELECTED_BASEMAPS <- leaflet::providers[c("Stamen.TonerLite", "CartoDB.Positron", "OpenStreetMap")]
+  SELECTED_BASEMAPS <- leaflet::providers[c("CartoDB.Positron", "OpenStreetMap", "Stamen.TonerLite")]
 
   # Add the basemap tiles in background
   # http://rstudio.github.io/leaflet/morefeatures.html


### PR DESCRIPTION
# Summary

Until stamen basemap locations are corrected (see #54), use CartoDB Positron as the default basemap for all interactive maps.

# Changes

The changes made in this PR are:

1. Change the default basemap to `"CartoDB.Positron"` for all interactive maps, which include:
    1. collision location map
    1. gridded choropleth maps of collisions in each district
    1. hotzone streets location

![main-map-cartodb](https://user-images.githubusercontent.com/29334677/184704155-b0fcd582-35a6-4de7-ae27-9050436090e7.jpg)

![collision-map-cartodb](https://user-images.githubusercontent.com/29334677/184704321-2183fe2b-0549-4934-abb9-90b608831633.jpg)

![hotzone-cartodb](https://user-images.githubusercontent.com/29334677/184704328-60fb7834-9e43-4887-b145-4fcd792c8a90.jpg)

***

# Check

- [x] The travis.ci and R CMD checks pass.
