### PR TITLE
Feat: Improve cartography of hotzone interactive map

### DIFF
--- a/inst/app/modules/hotzones.R
+++ b/inst/app/modules/hotzones.R
@@ -26,7 +26,7 @@ output$hotspots_map = renderTmap({
       title.col = "Hotzone Rank",
       id = "Name",
       col = "Area_RK",
-      lwd = 2.5,
+      lwd = 7.5,
       palette = "inferno",
       # Use only first half of inferno palette as the light color part does not show well on grey basemap
       contrast = c(0, .5),

--- a/inst/app/modules/hotzones.R
+++ b/inst/app/modules/hotzones.R
@@ -18,7 +18,7 @@ TABLE_COLUMN_NAMES = c(
 
 
 # Interactive heatmap
-output$hotspots_map = renderTmap({
+output$hotzones_map = renderTmap({
 
   tm_shape(hotzone_streets) +
     tm_lines(
@@ -49,7 +49,7 @@ observe({
   if (is.null(input$goto)) return()
 
   isolate({
-    map = leafletProxy("hotspots_map")
+    map = leafletProxy("hotzones_map")
 
     lat = input$goto$lat
     lng = input$goto$lng
@@ -58,7 +58,7 @@ observe({
   })
 })
 
-output$hotspots_table = renderDataTable({
+output$hotzones_table = renderDataTable({
 
   # `rownames` needs to be consistent with `DT::datatable` option
   action = DT::dataTableAjax(session, hotzone_out_df, rownames = FALSE)

--- a/inst/app/modules/hotzones.R
+++ b/inst/app/modules/hotzones.R
@@ -20,8 +20,7 @@ TABLE_COLUMN_NAMES = c(
 # Interactive heatmap
 output$hotspots_map = renderTmap({
 
-  tm_tiles(COLLISION_PTS_TILE_URL, group = "Collisions with pedestrian injuries") +
-    tm_shape(hotzone_streets) +
+  tm_shape(hotzone_streets) +
     tm_lines(
       group = "Hotzone streets",
       title.col = "Hotzone Rank",
@@ -40,7 +39,8 @@ output$hotspots_map = renderTmap({
         "Collisions between 2015 to 2019: " = "N_Colli",
         "Segement Length (m): " = "Road_Length"
         )
-    )
+    ) +
+    tm_tiles(COLLISION_PTS_TILE_URL, group = "Collisions with pedestrian injuries")
 
 })
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -441,14 +441,14 @@ ui <- dashboardPage(
           box(
             width = 12,
             title = "Pedestrian Collision Hot Zones",
-            tmapOutput(outputId = "hotspots_map")
+            tmapOutput(outputId = "hotzones_map")
           )
         ),
         fluidRow(
           box(
             width = 12,
             title = "Hot Zones Table",
-            dataTableOutput(outputId = "hotspots_table")
+            dataTableOutput(outputId = "hotzones_table")
 
           )
         )


### PR DESCRIPTION
# Summary

This branch adds cartographic improvements to the hotzone interactive map in the *Pedestrian Collision Hotzones* tab.

# Changes
The changes made in this PR are:

1. Put the hotzone streets line layer under the collision location point tile.
1. Increase the line width of hotzone layer to make it look more "balanced". It "fills up" the whole street in the basemap.
1. [Minor refactor] Replace `hotspots` in variable names to `hotzones`

### Before

![hotzone-before-carto](https://user-images.githubusercontent.com/29334677/184976646-89a0807f-ed64-445d-a9b1-c2303df3d93e.jpg)

### After

![hotzone-after-carto](https://user-images.githubusercontent.com/29334677/184976656-36b29d68-6167-4c53-b0e6-e23cf75a22c7.jpg)

***

# Check

- [x] The travis.ci and R CMD checks pass.
