### PR TITLE
Feat: Refine element alignments in severity filter

### DIFF
--- a/inst/app/www/styles.css
+++ b/inst/app/www/styles.css
@@ -104,6 +104,8 @@
 */
 
 .filter__circle-marker {
+  /* Align the circle marker to left together with the flex-grow prop of .filter__text */
+  flex-grow: 0;
   height: 14px;
   width: 14px;
   border-radius: 50%;
@@ -111,8 +113,9 @@
 }
 
 .filter__text {
+  /* Align the text to center together with the flex-grow prop of .filter__circle-marker */
+  flex-grow: 1;
   color:black;
-  padding-left:10px;
 }
 
 /* Hide / Show all button in collapsible group checkbox */


### PR DESCRIPTION
# Summary
This branch Align circle marker to left and text to center In the severity filter. 

# Changes

The changes made in this PR are:

1. Align the circle marker in the severity filter to left
1. Align the text in the severity filter to center

This is made by adjusting the `flex-grow` properties in flexbox.

### Existing element alignments

<img width="274" alt="old-alignment" src="https://user-images.githubusercontent.com/29334677/185645438-d946b15b-edf9-4b10-bb7c-31dc3a66b886.png">


### Proposed element alignments

<img width="221" alt="new-alignment" src="https://user-images.githubusercontent.com/29334677/185645461-bcc056d9-db48-4ad7-bc66-9de1c51f4a47.png">

The buttons are responsive to the layout.

https://user-images.githubusercontent.com/29334677/185645938-9b35b874-7b93-40b2-b7ef-dcdc09a5f08b.mp4


***

# Check

- [x] The travis.ci and R CMD checks pass.
