### PR TITLE
Feat: Update default selected filters and map location

### DIFF
--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -1,6 +1,7 @@
 output$main_map <- renderLeaflet({
   overview_map <- leaflet(options = leafletOptions(minZoom = 11, preferCanvas = TRUE)) %>%
-    setView(lng = 114.2, lat = 22.3, zoom = 12) %>%
+    # Set default location to Mong Kok
+    setView(lng = 114.17, lat = 22.31, zoom = 16) %>%
     # Add geocoder map widget
     addSearchOSM(options = searchOptions(hideMarkerOnCollapse = TRUE))
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -161,13 +161,14 @@ ui <- dashboardPage(
                 inputId = "district_filter",
                 label = "District(s):",
                 choices = setNames(DISTRICT_ABBR, DISTRICT_FULL_NAME),
-                selected = "KC",
+                multiple = TRUE,
+                selected = c("KC", "YTM", "SSP"),
                 options = list(maxItems = 3, placeholder = 'Select districts (3 maximum)')
               ),
 
               airDatepickerInput("start_month",
                                  label = "From",
-                                 value = "2016-05-01",
+                                 value = "2016-01-01",
                                  min = as.Date(min(hk_accidents$Date_Time), tz = "Asia/Hong_Kong"),
                                  max = as.Date(max(hk_accidents$Date_Time), tz = "Asia/Hong_Kong"),
                                  view = "months",
@@ -178,7 +179,7 @@ ui <- dashboardPage(
 
               airDatepickerInput("end_month",
                                  label = "To",
-                                 value = "2016-06-01",
+                                 value = "2016-12-01",
                                  min = as.Date(min(hk_accidents$Date_Time), tz = "Asia/Hong_Kong"),
                                  max = as.Date(max(hk_accidents$Date_Time), tz = "Asia/Hong_Kong"),
                                  view = "months",
@@ -210,7 +211,7 @@ ui <- dashboardPage(
                 i = 3,
                 # reverse alphabetical order
                 choices = sort(unique(hk_accidents$Type_of_Collision_with_cycle), decreasing = TRUE),
-                selected = unique(hk_accidents$Type_of_Collision_with_cycle)
+                selected = c("Vehicle collision with Pedestrian", "Pedal Cycle collision with Pedestrian")
               ),
 
               collapsibleAwesomeCheckboxGroupInput(


### PR DESCRIPTION
# Summary

This branch updates default selected filters and map location.

# Changes

The changes made in this PR are:

1. Update the default values of the filters of the collision map, including:
    1. Change the default selected time period from *May 2016 - Jun 2016* to *Jan 2016 - Dec 2016*
    1. Change default selected districts from *Kowloon City* to *"Kowloon City, Yau Tsim Mong and Shum Shui Po"*
    1. Change the default selected collision type from *all collision type* to *pedestrian-related collision only*
1. Update default location of collision map to Mong Kok, with a larger zoom level (16) to see the collision point by point

### Existing collision map default view

![map-original-view](https://user-images.githubusercontent.com/29334677/185650617-4c1cb9c8-ceac-4af2-90d1-6a2eb40178cc.jpg)

### Proposed collision map default view

![map-new-view](https://user-images.githubusercontent.com/29334677/185650628-ef636f68-309f-4d4c-970f-96c2ccb386cd.jpg)



***

# Check

- [x] The travis.ci and R CMD checks pass.

