### PR TITLE
Feat: Add help buttons for filters

### DIFF
--- a/inst/app/desc/collision_type_filter.md
+++ b/inst/app/desc/collision_type_filter.md
@@ -1,0 +1,1 @@
+Collision type refers to *"which vehicle type"* collide into *"what object"*. In this filter, vehicle types are classified into two categories: vehicle and pedal cycle. The object are classified into five categories: vehicle, pedal cycle, pedestrian, object and nothing.

--- a/inst/app/desc/date_filter.md
+++ b/inst/app/desc/date_filter.md
@@ -1,0 +1,7 @@
+Two calender inputs are used filter the time range of the collision. Collisions happened on or after the month in the **From** input date and happened on or before the month in the **To** input date will be shown on the map.
+
+To use this time range filter:
+
+1. Click on the input box. A calendar will appear.
+2. On the top of the calendar, select the year. You could also go to the previous/next year by clicking on the left/right arrow on the top left/top right corner.
+3. Click on the month. The month text will turns to blue, indicating your current selected Year-Month.

--- a/inst/app/desc/district_filter.md
+++ b/inst/app/desc/district_filter.md
@@ -1,0 +1,5 @@
+This filter refers to the area/district you are interested to look into.
+
+Type in the names of the district, then click on the name of the desired district to include collision in that district to the map. Autocomplete function is also available.
+
+Due to the limitation of server load, you can only choose **3 districts at most** at one time (We know, it's not ideal).

--- a/inst/app/desc/severity_filter.md
+++ b/inst/app/desc/severity_filter.md
@@ -1,0 +1,6 @@
+Collision severity refers to the level of seriousness of the traffic collisions. Definitions of each descriptive term are available below:
+
+- **Fatal**: Traffic accident in which one or more persons dies within 30 days of the accident.
+- **Serious**: Traffic collision in which one or more persons injured and detained in hospital for more than twelve hours.
+- **Slight**: Traffic accident in which all persons involved are either not detained in hospitals or detained for not more than twelve hours.
+

--- a/inst/app/desc/vehicle_class_filter.md
+++ b/inst/app/desc/vehicle_class_filter.md
@@ -1,0 +1,4 @@
+Vehicle classes involved in the collision refers to the which type of vehicles are involved in the collision.
+
+Note that checking multiple boxes means to filter collisions including ANY of the selected vehicle classes, instead of ALL selected classes. For example, when both *Taxi* and *Light goods vehicle* boxes are selected, any collisions involving taxis or light good vehicles are shown.
+                

--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -17,6 +17,7 @@ library(hkdatasets)
 library(shiny)
 library(shinydashboard)
 library(shinyWidgets)
+library(shinyhelper)
 library(ggplot2)
 library(plotly)
 

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -10,6 +10,8 @@
 
 server <- function(input, output, session) {
 
+  shinyhelper::observe_helpers(help_dir = "desc")
+
   # ----- DATA MANIPULATION ----- #
   # Manipulation steps are conducted in "modules/manipulate_data.R", with
   # data exported to "data/data-manipulated/"

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -179,7 +179,11 @@ ui <- dashboardPage(
                                  minView = "months",
                                  dateFormat = "MM yyyy",
                                  addon = "none"
-              ),
+              ) %>%
+                shinyhelper::helper(
+                  type = "markdown", colour = "#0d0d0d",
+                  content = "date_filter"
+                ),
 
               airDatepickerInput("end_month",
                                  label = "To",

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -224,7 +224,11 @@ ui <- dashboardPage(
                 # reverse alphabetical order
                 choices = sort(unique(hk_accidents$Type_of_Collision_with_cycle), decreasing = TRUE),
                 selected = c("Vehicle collision with Pedestrian", "Pedal Cycle collision with Pedestrian")
-              ),
+              ) %>%
+                shinyhelper::helper(
+                  type = "markdown", colour = "#0d0d0d",
+                  content = "collision_type_filter"
+                ),
 
               collapsibleAwesomeCheckboxGroupInput(
                 inputId = "vehicle_class_filter", label = "Vehicle classes involved in the collision",

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -204,7 +204,11 @@ ui <- dashboardPage(
                 selected = unique(hk_accidents$Severity),
                 direction = "vertical",
                 justified = TRUE
-              ),
+              ) %>%
+                shinyhelper::helper(
+                  type = "markdown", colour = "#0d0d0d",
+                  content = "severity_filter"
+                  ),
 
               collapsibleAwesomeCheckboxGroupInput(
                 inputId = "collision_type_filter", label = "Collision type",

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -231,11 +231,15 @@ ui <- dashboardPage(
                 ),
 
               collapsibleAwesomeCheckboxGroupInput(
-                inputId = "vehicle_class_filter", label = "Vehicle classes involved in the collision",
+                inputId = "vehicle_class_filter", label = "Vehicle classes involved",
                 i = 2,
                 choices = unique(hk_vehicles$Vehicle_Class),
                 selected = unique(hk_vehicles$Vehicle_Class)
-              ),
+              ) %>%
+                shinyhelper::helper(
+                  type = "markdown", colour = "#0d0d0d",
+                  content = "vehicle_class_filter"
+                ),
 
               br(),
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -164,7 +164,11 @@ ui <- dashboardPage(
                 multiple = TRUE,
                 selected = c("KC", "YTM", "SSP"),
                 options = list(maxItems = 3, placeholder = 'Select districts (3 maximum)')
-              ),
+              ) %>%
+                shinyhelper::helper(
+                  type = "markdown", colour = "#0d0d0d",
+                  content = "district_filter"
+                ),
 
               airDatepickerInput("start_month",
                                  label = "From",

--- a/renv.lock
+++ b/renv.lock
@@ -1025,6 +1025,17 @@
         "shiny"
       ]
     },
+    "shinyhelper": {
+      "Package": "shinyhelper",
+      "Version": "0.3.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "baef117734d5bd59373a561a15168679",
+      "Requirements": [
+        "markdown",
+        "shiny"
+      ]
+    },
     "sourcetools": {
       "Package": "sourcetools",
       "Version": "0.1.7",


### PR DESCRIPTION
# Summary

This branch adds help buttons (info buttons) for describing how to use the filters in the collision location map.

# Changes

The changes made in this PR are:

1. Add {shinyhelper} dependency. 
2. Add help buttons next to the following 5 filters:
     1. District filter
     2. Date filter
     3. Severity filter
     4. Collision type filter
     5. Vehicle class filter
3. Add help texts for the aforementioned buttons in the `inst/app/desc` folder.

![info-buttons-location](https://user-images.githubusercontent.com/29334677/185981707-7b9af6bd-94c6-4139-a4c7-ad1f18a05906.jpg)

https://user-images.githubusercontent.com/29334677/185981728-3aece3cc-06ad-47b6-8cc8-37d380222ce4.mp4

***

# Check

- [ ] The travis.ci and R CMD checks pass.

