### PR TITLE
Feat: Add embedded user survey Google Form

### DIFF
--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -98,6 +98,13 @@ ui <- dashboardPage(
         text = "Project Info",
         icon = icon(name = "info"),
         tabName = "tab_project_info"
+      ),
+
+      # User Survey
+      menuItem(
+        text = "User Survey",
+        icon = icon(name = "list"),
+        tabName = "tab_user_survey"
       )
 
     ) # sidebarMenu
@@ -530,6 +537,23 @@ ui <- dashboardPage(
             paste("Hong Kong Traffic Injury Collision Database ver.", get_last_modified_date(getwd())),
             br(),
             paste("hkdatasets ver.", utils::packageVersion("hkdatasets")),
+          )
+        )
+      ),
+
+      # Menu item: User Survey ---------------------------------------------------
+
+      tabItem(
+        tabName = "tab_user_survey",
+        fluidRow(
+          tags$iframe(
+            src = "https://docs.google.com/forms/d/e/1FAIpQLSd7mD-MiIn3T9wp3KREqut4BfzVFVXD-UfkWEf_-04Kg4kRVA/viewform?embedded=true",
+            width = "100%",
+            # TODO: Auto adjust height when form is updated; make the height responsive to users' device width
+            height = "3600px",
+            frameBorder= 0,
+            marginheight = 0,
+            marginwidth = 0
           )
         )
       ) # tabItem


### PR DESCRIPTION
# Summary

This branch adds an embedded Google Form for user survey.

# Changes
The changes made in this PR are:

1. Add a new tab in the sidebar named "User Survey"
1. Embed a Google Form in the "User Survey" tab

***

# Check

- [x] The travis.ci and R CMD checks pass.

***

## Note

The height of the embedded Google Form `iframe` is currently hardcoded. In terms of best practice, the height should be computed according to users' device width.
