### PR TITLE
Refactor: Remove conflict msgs in shiny app log

### DIFF
--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -9,17 +9,17 @@
 # Packages ----------------------------------------------------------------
 
 ## data wrangling
-library(dplyr)
+library(dplyr, warn.conflicts = FALSE)
 library(tidyr)
 library(hkdatasets)
 
 ## shiny-related
 library(shiny)
-library(shinydashboard)
+library(shinydashboard, warn.conflicts = FALSE)
 library(shinyWidgets)
 library(shinyhelper)
 library(ggplot2)
-library(plotly)
+library(plotly, warn.conflicts = FALSE)
 
 ## interactive map
 library(sf)
@@ -30,7 +30,7 @@ library(leaflet.extras)
 library(tmap)
 
 ## Interactive tables
-library(DT)
+library(DT, warn.conflicts = FALSE)
 
 
 # Metadata -------------------------------------------------------------


### PR DESCRIPTION
# Summary

This branch removes conflict messages in shiny app log. As the masked function behaviour is expected, it is unnecessary to keep the conflict messages. This also reduces the number of unnecessary logs in the shiny app.

***

# Check

- [x] The travis.ci and R CMD checks pass.

***

## Note

The current list of objects masked when attaching the library are listed below.

```
Attaching package: ‘dplyr’

The following objects are masked from ‘package:stats’:

    filter, lag

The following objects are masked from ‘package:base’:

    intersect, setdiff, setequal, union

...

Attaching package: ‘shinydashboard’

The following object is masked from ‘package:graphics’:

    box

...

Attaching package: ‘plotly’

The following object is masked from ‘package:ggplot2’:

    last_plot

The following object is masked from ‘package:stats’:

    filter

The following object is masked from ‘package:graphics’:

    layout

...

Attaching package: ‘DT’

The following objects are masked from ‘package:shiny’:

    dataTableOutput, renderDataTable
```
