### PR TITLE
Feat: Add live translation to collision map filter panel

### DIFF
--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -2,6 +2,33 @@
 ## Filter UI
 #############
 
+output$collision_type_filter_ui = renderUI({
+  collapsibleAwesomeCheckboxGroupInput(
+    inputId = "collision_type_filter", label = i18n$t("Collision type"),
+    i = 3,
+    # reverse alphabetical order
+    choices = stats::setNames(
+      sort(unique(hk_accidents$Type_of_Collision_with_cycle), decreasing = TRUE),
+      c(
+        i18n$t("Vehicle collision with Vehicle"),
+        i18n$t("Vehicle collision with Pedestrian"),
+        i18n$t("Vehicle collision with Pedal Cycle"),
+        i18n$t("Vehicle collision with Object"),
+        i18n$t("Vehicle collision with Nothing"),
+        i18n$t("Pedal Cycle collision with Pedestrian"),
+        i18n$t("Pedal Cycle collision with Pedal Cycle"),
+        i18n$t("Pedal Cycle collision with Object"),
+        i18n$t("Pedal Cycle collision with Nothing")
+      )
+    ),
+    selected = c("Vehicle collision with Pedestrian")
+  ) %>%
+    shinyhelper::helper(
+      type = "markdown", colour = "#0d0d0d",
+      content = "collision_type_filter"
+    )
+})
+
 output$vehicle_class_filter_ui = renderUI({
   collapsibleAwesomeCheckboxGroupInput(
     inputId = "vehicle_class_filter", label = i18n$t("Vehicle classes involved"),
@@ -32,6 +59,9 @@ output$vehicle_class_filter_ui = renderUI({
       content = "vehicle_class_filter"
     )
 })
+
+
+
 
 #############
 ## Main Map

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -1,6 +1,42 @@
 #############
 ## Filter UI
 #############
+output$district_filter_ui = renderUI({
+  selectizeInput(
+    inputId = "district_filter",
+    label = i18n$t("District(s)"),
+    choices = stats::setNames(
+      DISTRICT_ABBR,
+      c(
+        i18n$t("Central and Western"),
+        i18n$t("Wan Chai"),
+        i18n$t("Eastern"),
+        i18n$t("Southern"),
+        i18n$t("Yau Tsim Mong"),
+        i18n$t("Sham Shui Po"),
+        i18n$t("Kowloon City"),
+        i18n$t("Wong Tai Sin"),
+        i18n$t("Kwun Tong"),
+        i18n$t("Tsuen Wan"),
+        i18n$t("Tuen Mun"),
+        i18n$t("Yuen Long"),
+        i18n$t("North"),
+        i18n$t("Tai Po"),
+        i18n$t("Sai Kung"),
+        i18n$t("Sha Tin"),
+        i18n$t("Kwai Tsing"),
+        i18n$t("Islands")
+      )
+    ),
+    multiple = TRUE,
+    selected = c("KC", "YTM", "SSP"),
+    options = list(maxItems = 3, placeholder = 'Select districts (3 maximum)')
+  ) %>%
+    shinyhelper::helper(
+      type = "markdown", colour = "#0d0d0d",
+      content = "district_filter"
+    )
+})
 
 output$start_month_ui = renderUI({
   airDatepickerInput("start_month",

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -2,6 +2,39 @@
 ## Filter UI
 #############
 
+output$start_month_ui = renderUI({
+  airDatepickerInput("start_month",
+                     label = i18n$t("From"),
+                     value = "2016-01-01",
+                     min = as.Date(min(hk_accidents$Date_Time), tz = "Asia/Hong_Kong"),
+                     max = as.Date(max(hk_accidents$Date_Time), tz = "Asia/Hong_Kong"),
+                     view = "months",
+                     minView = "months",
+                     dateFormat = "MM yyyy",
+                     language = input$selected_language,
+                     addon = "none"
+  ) %>%
+    shinyhelper::helper(
+      type = "markdown", colour = "#0d0d0d",
+      content = "date_filter"
+    )
+})
+
+output$end_month_ui = renderUI({
+  airDatepickerInput("end_month",
+                     label = i18n$t("To"),
+                     value = "2016-12-01",
+                     min = as.Date(min(hk_accidents$Date_Time), tz = "Asia/Hong_Kong"),
+                     max = as.Date(max(hk_accidents$Date_Time), tz = "Asia/Hong_Kong"),
+                     view = "months",
+                     minView = "months",
+                     dateFormat = "MM yyyy",
+                     language = input$selected_language,
+                     addon = "none"
+  )
+
+})
+
 output$collision_type_filter_ui = renderUI({
   collapsibleAwesomeCheckboxGroupInput(
     inputId = "collision_type_filter", label = i18n$t("Collision type"),

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -7,26 +7,7 @@ output$district_filter_ui = renderUI({
     label = i18n$t("District(s)"),
     choices = stats::setNames(
       DISTRICT_ABBR,
-      c(
-        i18n$t("Central and Western"),
-        i18n$t("Wan Chai"),
-        i18n$t("Eastern"),
-        i18n$t("Southern"),
-        i18n$t("Yau Tsim Mong"),
-        i18n$t("Sham Shui Po"),
-        i18n$t("Kowloon City"),
-        i18n$t("Wong Tai Sin"),
-        i18n$t("Kwun Tong"),
-        i18n$t("Tsuen Wan"),
-        i18n$t("Tuen Mun"),
-        i18n$t("Yuen Long"),
-        i18n$t("North"),
-        i18n$t("Tai Po"),
-        i18n$t("Sai Kung"),
-        i18n$t("Sha Tin"),
-        i18n$t("Kwai Tsing"),
-        i18n$t("Islands")
-      )
+      lapply(DISTRICT_FULL_NAME, function(x) i18n$t(x))
     ),
     multiple = TRUE,
     selected = c("KC", "YTM", "SSP"),
@@ -71,24 +52,16 @@ output$end_month_ui = renderUI({
 
 })
 
+collision_type_choices = sort(unique(hk_accidents$Type_of_Collision_with_cycle), decreasing = TRUE)
+
 output$collision_type_filter_ui = renderUI({
   collapsibleAwesomeCheckboxGroupInput(
     inputId = "collision_type_filter", label = i18n$t("Collision type"),
     i = 3,
     # reverse alphabetical order
     choices = stats::setNames(
-      sort(unique(hk_accidents$Type_of_Collision_with_cycle), decreasing = TRUE),
-      c(
-        i18n$t("Vehicle collision with Vehicle"),
-        i18n$t("Vehicle collision with Pedestrian"),
-        i18n$t("Vehicle collision with Pedal Cycle"),
-        i18n$t("Vehicle collision with Object"),
-        i18n$t("Vehicle collision with Nothing"),
-        i18n$t("Pedal Cycle collision with Pedestrian"),
-        i18n$t("Pedal Cycle collision with Pedal Cycle"),
-        i18n$t("Pedal Cycle collision with Object"),
-        i18n$t("Pedal Cycle collision with Nothing")
-      )
+      collision_type_choices,
+      lapply(collision_type_choices, function(x) {i18n$t(x)})
     ),
     selected = c("Vehicle collision with Pedestrian")
   ) %>%
@@ -98,27 +71,15 @@ output$collision_type_filter_ui = renderUI({
     )
 })
 
+vehicle_class_choices = unique(hk_vehicles$Vehicle_Class)
+
 output$vehicle_class_filter_ui = renderUI({
   collapsibleAwesomeCheckboxGroupInput(
     inputId = "vehicle_class_filter", label = i18n$t("Vehicle classes involved"),
     i = 2,
     choices = stats::setNames(
-      unique(hk_vehicles$Vehicle_Class),
-      c(
-        i18n$t("Private car"),
-        i18n$t("Public franchised bus"),
-        i18n$t("Taxi"),
-        i18n$t("Motorcycle"),
-        i18n$t("Light goods vehicle"),
-        i18n$t("Bicycle"),
-        i18n$t("Heavy goods vehicle"),
-        i18n$t("Medium goods vehicle"),
-        i18n$t("Tram"),
-        i18n$t("Public light bus"),
-        i18n$t("Others (incl. unknown)"),
-        i18n$t("Public non-franchised bus"),
-        i18n$t("Light rail vehicle")
-      )
+      vehicle_class_choices,
+      lapply(vehicle_class_choices, function(x) {i18n$t(x)})
     )
     ,
     selected = unique(hk_vehicles$Vehicle_Class)

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -1,3 +1,42 @@
+#############
+## Filter UI
+#############
+
+output$vehicle_class_filter_ui = renderUI({
+  collapsibleAwesomeCheckboxGroupInput(
+    inputId = "vehicle_class_filter", label = i18n$t("Vehicle classes involved"),
+    i = 2,
+    choices = stats::setNames(
+      unique(hk_vehicles$Vehicle_Class),
+      c(
+        i18n$t("Private car"),
+        i18n$t("Public franchised bus"),
+        i18n$t("Taxi"),
+        i18n$t("Motorcycle"),
+        i18n$t("Light goods vehicle"),
+        i18n$t("Bicycle"),
+        i18n$t("Heavy goods vehicle"),
+        i18n$t("Medium goods vehicle"),
+        i18n$t("Tram"),
+        i18n$t("Public light bus"),
+        i18n$t("Others (incl. unknown)"),
+        i18n$t("Public non-franchised bus"),
+        i18n$t("Light rail vehicle")
+      )
+    )
+    ,
+    selected = unique(hk_vehicles$Vehicle_Class)
+  ) %>%
+    shinyhelper::helper(
+      type = "markdown", colour = "#0d0d0d",
+      content = "vehicle_class_filter"
+    )
+})
+
+#############
+## Main Map
+#############
+
 output$main_map <- renderLeaflet({
   overview_map <- leaflet(options = leafletOptions(minZoom = 11, preferCanvas = TRUE)) %>%
     # Set default location to Mong Kok

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -130,8 +130,18 @@ output$nrow_filtered <- reactive(format(nrow(filter_collision_data()), big.mark 
 # Filter the collision data according to users' input
 filter_collision_data <- reactive({
 
-  data_filtered = filter(hk_accidents_valid_sf,
-                         year_month >= floor_date_to_month(input$start_month) & year_month <= floor_date_to_month(input$end_month))
+  # Test for checking initialise value of date, will return TRUE when render airDatepickerInput in server side
+  # message("is.null(input$end_month): ", is.null(input$end_month))
+
+  # HACK: Temp workaround to fix non-initialised month value when airDatepickerInput renders in server side
+  if (is.null(input$end_month)) {
+    data_filtered = filter(hk_accidents_valid_sf,
+                           year_month >= floor_date_to_month(as.Date("2016-01-01")) & year_month <= floor_date_to_month(as.Date("2016-12-01")))
+  } else {
+    data_filtered = filter(hk_accidents_valid_sf,
+                           year_month >= floor_date_to_month(input$start_month) & year_month <= floor_date_to_month(input$end_month))
+  }
+
 
   message("Min date in filtered data: ", min(data_filtered$Date_Time))
   message("Max date in filtered data: ", max(data_filtered$Date_Time))

--- a/inst/app/translation/translation_zh.csv
+++ b/inst/app/translation/translation_zh.csv
@@ -15,6 +15,9 @@ Collision severity,車禍嚴重程度
 Collision type,車禍類別
 Vehicle classes involved,涉事車輛類別
 Number of collisions in current filter settings: ,符合現有篩選組合之車禍總數：
+Fatal,致命
+Serious,嚴重
+Slight,輕微
 Vehicle collision with Object,車撞物
 Vehicle collision with Nothing,車輛沒有踫撞
 Vehicle collision with Vehicle,車撞車

--- a/inst/app/translation/translation_zh.csv
+++ b/inst/app/translation/translation_zh.csv
@@ -15,6 +15,24 @@ Collision severity,車禍嚴重程度
 Collision type,車禍類別
 Vehicle classes involved,涉事車輛類別
 Number of collisions in current filter settings: ,符合現有篩選組合之車禍總數：
+Central and Western,中西區
+Wan Chai,灣仔區
+Eastern,東區
+Southern,南區
+Yau Tsim Mong,油尖旺區
+Sham Shui Po,深水埗區
+Kowloon City,九龍城區
+Wong Tai Sin,黃大仙區
+Kwun Tong,觀塘區
+Tsuen Wan,荃灣區
+Tuen Mun,屯門區
+Yuen Long,元朗區
+North,北區
+Tai Po,大埔區
+Sai Kung,西貢區
+Sha Tin,沙田區
+Kwai Tsing,葵青區
+Islands,離島區
 Fatal,致命
 Serious,嚴重
 Slight,輕微

--- a/inst/app/translation/translation_zh.csv
+++ b/inst/app/translation/translation_zh.csv
@@ -15,6 +15,15 @@ Collision severity,車禍嚴重程度
 Collision type,車禍類別
 Vehicle classes involved,涉事車輛類別
 Number of collisions in current filter settings: ,符合現有篩選組合之車禍總數：
+Vehicle collision with Object,車撞物
+Vehicle collision with Nothing,車輛沒有踫撞
+Vehicle collision with Vehicle,車撞車
+Pedal Cycle collision with Nothing,單車沒有踫撞
+Vehicle collision with Pedestrian,車撞行人
+Pedal Cycle collision with Pedestrian,單車撞行人
+Vehicle collision with Pedal Cycle,車撞單車
+Pedal Cycle collision with Object,單車撞物
+Pedal Cycle collision with Pedal Cycle,單車撞單車
 Private car,私家車
 Public franchised bus,公共專營巴士
 Taxi,的士

--- a/inst/app/translation/translation_zh.csv
+++ b/inst/app/translation/translation_zh.csv
@@ -15,3 +15,16 @@ Collision severity,車禍嚴重程度
 Collision type,車禍類別
 Vehicle classes involved,涉事車輛類別
 Number of collisions in current filter settings: ,符合現有篩選組合之車禍總數：
+Private car,私家車
+Public franchised bus,公共專營巴士
+Taxi,的士
+Motorcycle,電單車
+Light goods vehicle,輕型貨車
+Bicycle,單車
+Heavy goods vehicle,重型貨車
+Medium goods vehicle,中型貨車
+Tram,電車
+Public light bus,公共小巴
+Others (incl. unknown),其他（包括類別不詳車輛）
+Public non-franchised bus,公共非專營巴士
+Light rail vehicle,輕鐵車輛

--- a/inst/app/translation/translation_zh.csv
+++ b/inst/app/translation/translation_zh.csv
@@ -7,3 +7,11 @@ Key Facts,行人車禍概要
 Data Download,數據下載
 Project Info,闗於此專案
 User Survey,用戶問卷調查
+Filters,篩選分類
+District(s),地區
+From,由（年月）
+To,至（年月）
+Collision severity,車禍嚴重程度
+Collision type,車禍類別
+Vehicle classes involved,涉事車輛類別
+Number of collisions in current filter settings: ,符合現有篩選組合之車禍總數：

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -224,9 +224,9 @@ ui <- dashboardPage(
                 inputId = "severity_filter", label = i18n$t("Collision severity"),
                 # TODO: use sprintf and global SEVERITY_COLOR constant for mapping icon color
                 choiceNames = c(
-                  '<div style="display: flex;justify-content: center;align-items: center;"><span class="filter__circle-marker" style="background-color: #FF4039;"></span><span class="filter__text">Fatal</span></div>',
-                  '<div style="display: flex;justify-content: center;align-items: center;"><span class="filter__circle-marker" style="background-color: #FFB43F;"></span><span class="filter__text">Serious</span></div>',
-                  '<div style="display: flex;justify-content: center;align-items: center;"><span class="filter__circle-marker" style="background-color: #FFE91D"></span><span class="filter__text">Slight</span></div>'
+                  paste0('<div style="display: flex;justify-content: center;align-items: center;"><span class="filter__circle-marker" style="background-color: #FF4039;"></span><span class="filter__text">', i18n$t("Fatal"), '</span></div>'),
+                  paste0('<div style="display: flex;justify-content: center;align-items: center;"><span class="filter__circle-marker" style="background-color: #FFB43F;"></span><span class="filter__text">', i18n$t("Serious"), '</span></div>'),
+                  paste0('<div style="display: flex;justify-content: center;align-items: center;"><span class="filter__circle-marker" style="background-color: #FFE91D"></span><span class="filter__text">', i18n$t("Slight"), '</span></div>')
                   ),
                 choiceValues = c(
                   "Fatal",

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -194,31 +194,9 @@ ui <- dashboardPage(
                   content = "district_filter"
                 ),
 
-              airDatepickerInput("start_month",
-                                 label = i18n$t("From"),
-                                 value = "2016-01-01",
-                                 min = as.Date(min(hk_accidents$Date_Time), tz = "Asia/Hong_Kong"),
-                                 max = as.Date(max(hk_accidents$Date_Time), tz = "Asia/Hong_Kong"),
-                                 view = "months",
-                                 minView = "months",
-                                 dateFormat = "MM yyyy",
-                                 addon = "none"
-              ) %>%
-                shinyhelper::helper(
-                  type = "markdown", colour = "#0d0d0d",
-                  content = "date_filter"
-                ),
+              uiOutput("start_month_ui"),
 
-              airDatepickerInput("end_month",
-                                 label = i18n$t("To"),
-                                 value = "2016-12-01",
-                                 min = as.Date(min(hk_accidents$Date_Time), tz = "Asia/Hong_Kong"),
-                                 max = as.Date(max(hk_accidents$Date_Time), tz = "Asia/Hong_Kong"),
-                                 view = "months",
-                                 minView = "months",
-                                 dateFormat = "MM yyyy",
-                                 addon = "none"
-              ),
+              uiOutput("end_month_ui"),
 
               checkboxGroupButtons(
                 inputId = "severity_filter", label = i18n$t("Collision severity"),

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -181,18 +181,7 @@ ui <- dashboardPage(
 
               h3(span(icon("filter")), " ", i18n$t("Filters")),
 
-              selectizeInput(
-                inputId = "district_filter",
-                label = i18n$t("District(s)"),
-                choices = setNames(DISTRICT_ABBR, DISTRICT_FULL_NAME),
-                multiple = TRUE,
-                selected = c("KC", "YTM", "SSP"),
-                options = list(maxItems = 3, placeholder = 'Select districts (3 maximum)')
-              ) %>%
-                shinyhelper::helper(
-                  type = "markdown", colour = "#0d0d0d",
-                  content = "district_filter"
-                ),
+              uiOutput("district_filter_ui"),
 
               uiOutput("start_month_ui"),
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -254,16 +254,7 @@ ui <- dashboardPage(
                   content = "collision_type_filter"
                 ),
 
-              collapsibleAwesomeCheckboxGroupInput(
-                inputId = "vehicle_class_filter", label = i18n$t("Vehicle classes involved"),
-                i = 2,
-                choices = unique(hk_vehicles$Vehicle_Class),
-                selected = unique(hk_vehicles$Vehicle_Class)
-              ) %>%
-                shinyhelper::helper(
-                  type = "markdown", colour = "#0d0d0d",
-                  content = "vehicle_class_filter"
-                ),
+              uiOutput("vehicle_class_filter_ui"),
 
               br(),
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -242,17 +242,7 @@ ui <- dashboardPage(
                   content = "severity_filter"
                   ),
 
-              collapsibleAwesomeCheckboxGroupInput(
-                inputId = "collision_type_filter", label = i18n$t("Collision type"),
-                i = 3,
-                # reverse alphabetical order
-                choices = sort(unique(hk_accidents$Type_of_Collision_with_cycle), decreasing = TRUE),
-                selected = c("Vehicle collision with Pedestrian")
-              ) %>%
-                shinyhelper::helper(
-                  type = "markdown", colour = "#0d0d0d",
-                  content = "collision_type_filter"
-                ),
+              uiOutput("collision_type_filter_ui"),
 
               uiOutput("vehicle_class_filter_ui"),
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -179,11 +179,11 @@ ui <- dashboardPage(
               width = 3,
               id = "controls", class = "panel panel-default",
 
-              h3(span(icon("filter")), " Filters"),
+              h3(span(icon("filter")), " ", i18n$t("Filters")),
 
               selectizeInput(
                 inputId = "district_filter",
-                label = "District(s):",
+                label = i18n$t("District(s)"),
                 choices = setNames(DISTRICT_ABBR, DISTRICT_FULL_NAME),
                 multiple = TRUE,
                 selected = c("KC", "YTM", "SSP"),
@@ -195,7 +195,7 @@ ui <- dashboardPage(
                 ),
 
               airDatepickerInput("start_month",
-                                 label = "From",
+                                 label = i18n$t("From"),
                                  value = "2016-01-01",
                                  min = as.Date(min(hk_accidents$Date_Time), tz = "Asia/Hong_Kong"),
                                  max = as.Date(max(hk_accidents$Date_Time), tz = "Asia/Hong_Kong"),
@@ -210,7 +210,7 @@ ui <- dashboardPage(
                 ),
 
               airDatepickerInput("end_month",
-                                 label = "To",
+                                 label = i18n$t("To"),
                                  value = "2016-12-01",
                                  min = as.Date(min(hk_accidents$Date_Time), tz = "Asia/Hong_Kong"),
                                  max = as.Date(max(hk_accidents$Date_Time), tz = "Asia/Hong_Kong"),
@@ -221,7 +221,7 @@ ui <- dashboardPage(
               ),
 
               checkboxGroupButtons(
-                inputId = "severity_filter", label = "Collision severity",
+                inputId = "severity_filter", label = i18n$t("Collision severity"),
                 # TODO: use sprintf and global SEVERITY_COLOR constant for mapping icon color
                 choiceNames = c(
                   '<div style="display: flex;justify-content: center;align-items: center;"><span class="filter__circle-marker" style="background-color: #FF4039;"></span><span class="filter__text">Fatal</span></div>',
@@ -243,7 +243,7 @@ ui <- dashboardPage(
                   ),
 
               collapsibleAwesomeCheckboxGroupInput(
-                inputId = "collision_type_filter", label = "Collision type",
+                inputId = "collision_type_filter", label = i18n$t("Collision type"),
                 i = 3,
                 # reverse alphabetical order
                 choices = sort(unique(hk_accidents$Type_of_Collision_with_cycle), decreasing = TRUE),
@@ -255,7 +255,7 @@ ui <- dashboardPage(
                 ),
 
               collapsibleAwesomeCheckboxGroupInput(
-                inputId = "vehicle_class_filter", label = "Vehicle classes involved",
+                inputId = "vehicle_class_filter", label = i18n$t("Vehicle classes involved"),
                 i = 2,
                 choices = unique(hk_vehicles$Vehicle_Class),
                 selected = unique(hk_vehicles$Vehicle_Class)
@@ -267,7 +267,7 @@ ui <- dashboardPage(
 
               br(),
 
-              p("Number of collisions in current filter settings: ", textOutput("nrow_filtered", inline = TRUE),
+              p(i18n$t("Number of collisions in current filter settings: "), textOutput("nrow_filtered", inline = TRUE),
                 style = "font-size: 20px;text-align:center;"),
             )
           )

--- a/inst/app/www/styles.css
+++ b/inst/app/www/styles.css
@@ -120,13 +120,13 @@
 
 /* Hide / Show all button in collapsible group checkbox */
 .bttn-minimal.bttn-primary {
-  color: #0d0d0d;
+  color: #0d0d0d !important;
 }
 
 /* Color of checkboxes */
 .checkbox-primary input[type="checkbox"]:checked+label::before, .checkbox-primary input[type="radio"]:checked+label::before {
-  background-color: #0d0d0d;
-  border-color: #0d0d0d;
+  background-color: #0d0d0d !important;
+  border-color: #0d0d0d !important;
 }
 
 /* colour of the sliders */


### PR DESCRIPTION
# Summary

This branch adds live translation to collision map filter panel.

![overview](https://user-images.githubusercontent.com/29334677/188330875-4886a25c-07c6-4a3c-b172-0b8ac143227c.jpg)

https://user-images.githubusercontent.com/29334677/188330981-cb680d02-cea4-4560-b0af-7882fa6602c7.mp4


# Changes

The changes made in this PR are:

1. Add live translations to the text in the filter panel
1. Add live translation to the filters, including:
    - District filter

    ![district-filter](https://user-images.githubusercontent.com/29334677/188330986-f6b555d7-78e0-49a2-a758-b666ff37cceb.jpg)

    - Date filter (From and to)

    ![date-filter](https://user-images.githubusercontent.com/29334677/188330999-50557d14-6d10-4504-98f4-2cf44d590b9d.jpg)

    - Collision severity filter

    ![severity-filter](https://user-images.githubusercontent.com/29334677/188331046-f7a65426-4cac-448e-b229-eb7a1b60d69d.jpg)

    - Collision type filter

    ![collision-type-filter](https://user-images.githubusercontent.com/29334677/188330989-c69da1d4-07dc-40bf-b184-6e08db3e30ba.jpg)

    - Vehicle involved filter

    ![involved-vehicles-filter](https://user-images.githubusercontent.com/29334677/188330994-62cbec03-7bdf-4332-a8ac-a4c1214a5c2f.jpg)


***

# Check

- [x] (If UI & data are updated) The UI & data includes Traditional Chinese translation, with translation terms wrapped in `i18n$t()` and terms added to `translation_zh.csv`
- [x] The travis.ci and R CMD checks pass.

***

## Note

The helper texts inside the help icon (generated from `shinyhelper::helper`) are not yet translated. Chinese translation to the markdown documents ended with *_filter* in `desc` needs to be added.
