### PR TITLE
Feat: Use range input to select the date range of the collision filter

### DIFF
--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -28,7 +28,8 @@ output$month_range_ui = renderUI({
                      max = as.Date(max(hk_accidents$Date_Time), tz = "Asia/Hong_Kong"),
                      view = "months",
                      minView = "months",
-                     dateFormat = "MM yyyy",
+                     monthsField = "monthsShort",
+                     dateFormat = "M yyyy",
                      language = input$selected_language,
                      addon = "none"
   ) %>%

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -19,10 +19,11 @@ output$district_filter_ui = renderUI({
     )
 })
 
-output$start_month_ui = renderUI({
-  airDatepickerInput("start_month",
+output$month_range_ui = renderUI({
+  airDatepickerInput("month_range",
                      label = i18n$t("From"),
-                     value = "2016-01-01",
+                     range = TRUE,
+                     value = c("2016-01-01", "2016-12-01"),
                      min = as.Date(min(hk_accidents$Date_Time), tz = "Asia/Hong_Kong"),
                      max = as.Date(max(hk_accidents$Date_Time), tz = "Asia/Hong_Kong"),
                      view = "months",
@@ -35,21 +36,6 @@ output$start_month_ui = renderUI({
       type = "markdown", colour = "#0d0d0d",
       content = "date_filter"
     )
-})
-
-output$end_month_ui = renderUI({
-  airDatepickerInput("end_month",
-                     label = i18n$t("To"),
-                     value = "2016-12-01",
-                     min = as.Date(min(hk_accidents$Date_Time), tz = "Asia/Hong_Kong"),
-                     max = as.Date(max(hk_accidents$Date_Time), tz = "Asia/Hong_Kong"),
-                     view = "months",
-                     minView = "months",
-                     dateFormat = "MM yyyy",
-                     language = input$selected_language,
-                     addon = "none"
-  )
-
 })
 
 collision_type_choices = sort(unique(hk_accidents$Type_of_Collision_with_cycle), decreasing = TRUE)
@@ -131,12 +117,12 @@ filter_collision_data <- reactive({
   # message("is.null(input$end_month): ", is.null(input$end_month))
 
   # HACK: Temp workaround to fix non-initialised month value when airDatepickerInput renders in server side
-  if (is.null(input$end_month)) {
+  if (is.null(input$month_range)) {
     data_filtered = filter(hk_accidents_valid_sf,
                            year_month >= floor_date_to_month(as.Date("2016-01-01")) & year_month <= floor_date_to_month(as.Date("2016-12-01")))
   } else {
     data_filtered = filter(hk_accidents_valid_sf,
-                           year_month >= floor_date_to_month(input$start_month) & year_month <= floor_date_to_month(input$end_month))
+                           year_month >= floor_date_to_month(input$month_range[1]) & year_month <= floor_date_to_month(input$month_range[2]))
   }
 
 

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -21,7 +21,7 @@ output$district_filter_ui = renderUI({
 
 output$month_range_ui = renderUI({
   airDatepickerInput("month_range",
-                     label = i18n$t("From"),
+                     label = i18n$t("Date range"),
                      range = TRUE,
                      value = c("2016-01-01", "2016-12-01"),
                      min = as.Date(min(hk_accidents$Date_Time), tz = "Asia/Hong_Kong"),

--- a/inst/app/translation/translation_zh.csv
+++ b/inst/app/translation/translation_zh.csv
@@ -9,8 +9,7 @@ Project Info,闗於此專案
 User Survey,用戶問卷調查
 Filters,篩選分類
 District(s),地區
-From,由（年月）
-To,至（年月）
+Date range,日期範圍
 Collision severity,車禍嚴重程度
 Collision type,車禍類別
 Collision,車禍

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -183,9 +183,7 @@ ui <- dashboardPage(
 
               uiOutput("district_filter_ui"),
 
-              uiOutput("start_month_ui"),
-
-              uiOutput("end_month_ui"),
+              uiOutput("month_range_ui"),
 
               checkboxGroupButtons(
                 inputId = "severity_filter", label = i18n$t("Collision severity"),

--- a/inst/app/www/styles.css
+++ b/inst/app/www/styles.css
@@ -103,6 +103,22 @@
   Widgets
 */
 
+/* Override datepicker.min.css */
+.airdatepicker--cell.-in-range- {
+  background: rgba(13,13,13,.1) !important;
+}
+
+.airdatepicker--cell.-range-to- {
+  background: rgba(13,13,13,.1) !important;
+  border: 1px solid rgba(13,13,13,.5) !important;
+}
+
+/* -selected needs to placed below to override -range-to-, since end date have both properties */
+.airdatepicker--cell.-selected- {
+  background: #0d0d0d !important;
+}
+
+
 .filter__circle-marker {
   /* Align the circle marker to left together with the flex-grow prop of .filter__text */
   flex-grow: 0;


### PR DESCRIPTION
# Summary

This branch changes the start/end date filter to one single date picker (address and close #72).

# Changes

The changes made in this PR are:

1. Use the `range = TRUE` option to create a date range `airDatepickerInput`. This incorporates both `start_month` and `end_month` input value into one single calendar.
2. Shorten the name of the month to abbreviated version (e.g. `January` -> `Jan`)
3. Change the color of the date picker UI from default blue to black (`#0d0d0d`)

### After 

![after](https://user-images.githubusercontent.com/29334677/189642532-a7afe16e-d37d-4871-bfcc-7355273cbabe.jpg)


### Before

![before](https://user-images.githubusercontent.com/29334677/189637334-efab6dca-1b8a-4631-aa42-f638f76d0433.jpg)


***

# Check

- [x] (If UI & data are updated) The UI & data includes Traditional Chinese translation, with translation terms wrapped in `i18n$t()` and terms added to `translation_zh.csv`
- [x] The travis.ci and R CMD checks pass.
