### PR TITLE
Feat: Add link to Google Street View in popup

### DIFF
--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -208,7 +208,21 @@ observe({
     tags$b(i18n$t("Within 70 m of junctions? ")), ifelse(filter_collision_data()$Within_70m, i18n$t("Yes"), i18n$t("No")), tags$br(),
     # FIXME: Will impose warning messages if `Structure_Type` or `Road_Hierarchy` is NA
     tags$b(i18n$t("Road structure: ")), i18n$t(filter_collision_data()$Structure_Type), tags$br(),
-    tags$b(i18n$t("Road hierarchy: ")), i18n$t(filter_collision_data()$Road_Hierarchy)
+    tags$b(i18n$t("Road hierarchy: ")), i18n$t(filter_collision_data()$Road_Hierarchy),
+
+    tags$br(),
+    tags$br(),
+
+    # Use raw HTML since using tags$a() will result in error which link of all rows are included
+    # Because tags$a() vectorise and include all rows in one popup?
+    "<a href='",
+    # URL link of the street view, with bearing/zoom/tilt all set to 0
+    # https://developers.google.com/maps/documentation/urls/android-intents#display-a-street-view-panorama
+    "https://maps.google.com/?cbll=", filter_collision_data()$latitude, ",", filter_collision_data()$longitude, "&cbp=0,0,0,0,0&layer=c",
+    # open page in new tab
+    "' target='_blank' rel='noopener noreferrer'>",
+    "View this location in Google Street View",
+    "</a>"
 
   )
 

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -221,7 +221,7 @@ observe({
     "https://maps.google.com/?cbll=", filter_collision_data()$latitude, ",", filter_collision_data()$longitude, "&cbp=0,0,0,0,0&layer=c",
     # open page in new tab
     "' target='_blank' rel='noopener noreferrer'>",
-    "View this location in Google Street View",
+    i18n$t("View this location in Google Street View"),
     "</a>"
 
   )

--- a/inst/app/translation/translation_zh.csv
+++ b/inst/app/translation/translation_zh.csv
@@ -89,6 +89,7 @@ Underground road,地下道路
 Within 70 m of junctions? ,位處路口 70 米內？
 Yes,是
 No,否
+View this location in Google Street View,於 Google 街景顯示此車禍位置
 Hotzone streets,車禍熱區街道
 Hotzone Rank,熱區排名
 Collisions with pedestrian injuries,涉及行人傷亡車禍地點


### PR DESCRIPTION
# Summary

This branch adds link to Google Street View in popup.

# Changes

The changes made in this PR are:

1. Adds a link to Google Street View in the popup of the collision, which is in the format of
    ```
    https://maps.google.com/?cbll=latitude,longitude&cbp=0,bearing,0,zoom,tilt
    ```

When users click on the link, a new tab showing the street view will be opened.

https://user-images.githubusercontent.com/29334677/189707872-ad7afff9-7d12-4a9d-bf81-7addfe90de44.mp4


***

# Check

- [ ] (If UI & data are updated) The UI & data includes Traditional Chinese translation, with translation terms wrapped in `i18n$t()` and terms added to `translation_zh.csv`
- [ ] The travis.ci and R CMD checks pass.

***

## Note

Known issues of going to street view by only providing longitude and latitude:

1. Cannot distinguish whether location is in ground level/flyover/underground
2. When there is no street view available for the location of the collision point, the link will look for the nearest community-contributed panorama 