### PR TITLE
Feat: Complete traditional Chinese translation of website

### DIFF
--- a/inst/app/desc/hotzone.md
+++ b/inst/app/desc/hotzone.md
@@ -1,0 +1,3 @@
+此分頁顯示按車禍密度（每公里車禍事故次數）識別出之「行人車禍重災區」路段位置及其詳細資料。分析利用熱區（Hotzone Analysis）方法，詳情經已記載於[《交通意外不是意外 —— 香港行人車禍傷亡報告》](https://drive.google.com/file/d/1xLThTDhxnCszRCRdMHWLGwVsd1Ss1Jl_/view?usp=sharing)中「行人車禍熱區分析」之章節。
+
+This tab shows the location and information of the "pedestrian-related traffic collisions disaster area" identified using the Hotzone analysis method. Details of the analysis method are available in the "Pedestrian Collision Hotzone Analysis" Chapter of the [*‘Collision Not Accident’ - An Overview of Road Danger against Pedestrians in Hong Kong* report](https://drive.google.com/file/d/17eSbcPYrr2JwlMtKTLl7qvWMF-RsS4ug/view?usp=sharing).

--- a/inst/app/desc/information.md
+++ b/inst/app/desc/information.md
@@ -1,7 +1,17 @@
 
 [comment]: # (Use lv4 heading to match with the original heading styles in shinydashboard)
 
-#### <i class="fa fa-info" aria-label="info icon"></i> What is this website?
+#### <i class="fa fa-info" aria-label="info icon"></i> 關於此網站 What is this website?
+
+香港車禍傷亡資料庫是街道變革和 Hong Kong District Info 共同開發的項目，旨在利用互動地圖和儀表版，將香港車禍位置和相關數據可視化。這個項目有三個目標：
+
+- 提醒公眾注意目前香港車禍的嚴重性，尤其是對行人和單車使用者的嚴重影響
+- 讓各方注意到街道設計如何有份導致目前的情況，以及應採取哪些系統性的補救措施，以提高弱勢道路使用者的安全
+- 為記者、區議員和政府部門提供簡易數據和見解，有助深入探討及改善車禍問題
+
+**請注意：本網站之數據和信息僅供參考。雖然我們力求信息準確，但數據仍可能有誤，或所提供之資料並不完整。因此，我們對數據是否適合任何目的並不作任何保證或陳述。我們亦不對可能存在的遺漏或錯誤承擔任何責任。**
+
+<br>
 
 Hong Kong Traffic Injury Collision Database is a project co-developed by Street Reset and Hong Kong District Info, which aims to visualise Hong Kong traffic collision data with interactive mapping. Our objective is three-fold:
 
@@ -9,15 +19,25 @@ Hong Kong Traffic Injury Collision Database is a project co-developed by Street 
 -   To draw attention to how street design has contributed to the current situation, and what systemic remedies should be made to enhance the safety of vulnerable road users, and
 -   To provide journalists, district councillors, and government departments with insights and map-based data evidence to understand this issue.
 
-<br>
-
 **Please note that the data and information on this website are for informational purposes only. While we seek to provide accurate information, please note that errors may be present and information presented may not be complete. Accordingly, we make no representation with the respect to the suitability for any purposes. We also disclaim any liability for omissions or errors that may be contained therein.**
 
-<br>
+---
 
 <!-- ### How to use this database? -->
 
-#### <i class="fas fa-book"></i> Reference
+#### <i class="fas fa-book"></i> 參考資料 Reference
+
+運輸署有關車禍之數據及統計：
+
+- 道路交通意外統計 (https://www.td.gov.hk/tc/road_safety/road_traffic_accident_statistics/index.html)
+
+有關熱區分析方法：
+
+- Tsoi, Ka Ho Jason (2020) Where are the most dangerous road locations in Hong Kong?, ArcGIS StoryMap, https://arcg.is/jCWTX
+- Loo, B. P. Y. (2009) The Identification of Hazardous Road Locations: A Comparison of the Blacksite and Hot Zone Methodologies in Hong Kong, International Journal of Sustainable Transportation, Volume 3, 2009, Issue 3, Pages 187-202, https://www.tandfonline.com/doi/abs/10.1080/15568310801915583
+- Satria, R., Tsoi, K.H., Castro, M. and Loo, B.P.Y. (2020) A Combined Approach to Address Road Traffic Crashes beyond Cities: Hot Zone Identification and Countermeasures in Indonesia. Sustainability, 12(5), 1801. https://hub.hku.hk/bitstream/10722/284132/1/content.pdf 
+
+<br>
 
 For basic traffic collision figures and statistics provided by the Transport Department:
 

--- a/inst/app/desc/key_facts.md
+++ b/inst/app/desc/key_facts.md
@@ -1,13 +1,13 @@
-除了此資料庫網站，街道變革亦於 2022 年 8 月發佈了**《交通意外不是意外 —— 香港行人車禍傷亡報告》**。此報告有兩個主要目的：
+除了此資料庫網站，街道變革亦於 2022 年 8 月發佈了**《交通意外不是意外 —— 香港行人車禍傷亡報告》**。該報告有兩項目的：
 
 1. 分析 2015 至 2019 年間牽涉行人車禍的數據
 2. 制定一系列減低行人遭受車禍風險的措施
 
 報告可於網上查閱，並同時設有[中文版](https://drive.google.com/file/d/1xLThTDhxnCszRCRdMHWLGwVsd1Ss1Jl_/view?usp=sharing)及[英文版](https://drive.google.com/file/d/17eSbcPYrr2JwlMtKTLl7qvWMF-RsS4ug/view?usp=sharing)。
 
-下圖為報告之行政摘要，指出涉及行人的車禍之概要。
+下圖為報告之行政摘要，總括涉及行人的車禍之概要。
 
----
+<br>
 
 Together with this database website, Street Reset has published the *‘Collision Not Accident’ - An Overview of Road Danger against Pedestrians in Hong Kong* report on 2022 August. The report aims to:
 

--- a/inst/app/desc/key_facts.md
+++ b/inst/app/desc/key_facts.md
@@ -1,4 +1,15 @@
-Together with this database website, Street Reset has published the *‘Collision Not Accident’ - An Overview of Road Danger against Pedestrians in Hong Kong* report (交通意外不是意外 —— 香港行人車禍傷亡報告) on 2022 August. The report aims to:
+除了此資料庫網站，街道變革亦於 2022 年 8 月發佈了**《交通意外不是意外 —— 香港行人車禍傷亡報告》**。此報告有兩個主要目的：
+
+1. 分析 2015 至 2019 年間牽涉行人車禍的數據
+2. 制定一系列減低行人遭受車禍風險的措施
+
+報告可於網上查閱，並同時設有[中文版](https://drive.google.com/file/d/1xLThTDhxnCszRCRdMHWLGwVsd1Ss1Jl_/view?usp=sharing)及[英文版](https://drive.google.com/file/d/17eSbcPYrr2JwlMtKTLl7qvWMF-RsS4ug/view?usp=sharing)。
+
+下圖為報告之行政摘要，指出涉及行人的車禍之概要。
+
+---
+
+Together with this database website, Street Reset has published the *‘Collision Not Accident’ - An Overview of Road Danger against Pedestrians in Hong Kong* report on 2022 August. The report aims to:
 
 1. Identify the key characteristics and spatial clusters of all pedestrian collisions that happened between 2015 and 2019.
 2. Put forward a series of policy and design recommendations.

--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -49,8 +49,8 @@ OPENGRAPH_PROPS = list(
 # file with translations
 i18n = Translator$new(translation_csvs_path = "./translation")
 
-# change this to en
-i18n$set_translation_language("en")
+# Set Traditional Chinese as default language
+i18n$set_translation_language("zh")
 i18n$use_js()
 
 

--- a/inst/app/modules/hotzones.R
+++ b/inst/app/modules/hotzones.R
@@ -24,7 +24,7 @@ TABLE_COLUMN_NAMES_ZH = c(
   "重災區路段長度（米）" = "Road_Length",
   "2015 至 2019 年期間該路段發生之行人相關車禍總數" = "N_Colli",
   "車禍密度（每公里車禍總數）" = "Colli_Density",
-  "車禍熱區路段" = "Name_zh",
+  "車禍重災區路段" = "Name_zh",
   "地區" = "District_zh"
 )
 

--- a/inst/app/modules/hotzones.R
+++ b/inst/app/modules/hotzones.R
@@ -23,7 +23,7 @@ TABLE_COLUMN_NAMES_ZH = c(
   "於互動地圖顯示此路段" = "zoom_in_map_link",
   "重災區路段長度（米）" = "Road_Length",
   "2015 至 2019 年期間該路段發生之行人相關車禍總數" = "N_Colli",
-  "推算每公里車禍總數" = "Colli_Density",
+  "車禍密度（每公里車禍總數）" = "Colli_Density",
   "車禍熱區路段" = "Name_zh",
   "地區" = "District_zh"
 )

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -203,7 +203,7 @@ observe({
     tags$b(i18n$t("Number of vehicles: ")), filter_collision_data()$No_of_Vehicles_Involved, tags$br(),
     # Involved vehicle class
     # FIXME: Can't translate when collision includes >1 vehicle type
-    tags$b(i18n$t("Involved vehicle classes: ")), i18n$t(filter_collision_data()$vehicle_class_involved), tags$br(),
+    tags$b(i18n$t("Involved vehicle classes: ")), suppressWarnings(i18n$t(filter_collision_data()$vehicle_class_involved)), tags$br(),
 
     tags$br(),
 

--- a/inst/app/translation/translation_zh.csv
+++ b/inst/app/translation/translation_zh.csv
@@ -96,3 +96,6 @@ Hotzone Rank,重災區排名
 Collisions with pedestrian injuries,涉及行人傷亡車禍地點
 Hot Zone Name,車禍重災區路段
 Hotzones Table,行人車禍重災區詳細資料
+Key facts about pedestrian-related collisions,行人車禍概要
+Glossary of Terms,詞彙表
+The following terms are used in this website.,本網站使用之專用名詞及術語定義如下。

--- a/inst/app/translation/translation_zh.csv
+++ b/inst/app/translation/translation_zh.csv
@@ -2,7 +2,7 @@ en,zh
 Hong Kong Traffic Injury Collision Database,香港車禍傷亡資料庫
 Collision Location Map,車禍地圖
 Dashboard,地區儀表版
-Pedestrian collision hotzones,行人車禍熱區
+Pedestrian Collision Hotzones,行人車禍重災區
 Key Facts,行人車禍概要
 Data Download,數據下載
 Project Info,關於此專案
@@ -94,5 +94,4 @@ Hotzone streets,車禍熱區街道
 Hotzone Rank,熱區排名
 Collisions with pedestrian injuries,涉及行人傷亡車禍地點
 Hot Zone Name,車禍熱區路段
-Pedestrian Collision Hotzones,行人車禍熱區
 Hotzones Table,行人車禍熱區詳細資料

--- a/inst/app/translation/translation_zh.csv
+++ b/inst/app/translation/translation_zh.csv
@@ -1,7 +1,7 @@
 en,zh
 Hong Kong Traffic Injury Collision Database,香港車禍傷亡資料庫
 Collision Location Map,車禍地圖
-Dashboard,地區儀表版
+Dashboard,地區儀表版（暫只提供英文版）
 Pedestrian Collision Hotzones,行人車禍重災區
 Key Facts,行人車禍概要
 Data Download,數據下載

--- a/inst/app/translation/translation_zh.csv
+++ b/inst/app/translation/translation_zh.csv
@@ -5,7 +5,7 @@ Dashboard,地區儀表版
 Pedestrian collision hotzones,行人車禍熱區
 Key Facts,行人車禍概要
 Data Download,數據下載
-Project Info,闗於此專案
+Project Info,關於此專案
 User Survey,用戶問卷調查
 Filters,篩選分類
 District(s),地區

--- a/inst/app/translation/translation_zh.csv
+++ b/inst/app/translation/translation_zh.csv
@@ -91,8 +91,8 @@ Underground road,地下道路
 Within 70 m of junctions? ,位處路口 70 米內？
 Yes,是
 No,否
-Hotzone streets,車禍熱區街道
-Hotzone Rank,熱區排名
+Hotzone streets,車禍重災區路段
+Hotzone Rank,重災區排名
 Collisions with pedestrian injuries,涉及行人傷亡車禍地點
-Hot Zone Name,車禍熱區路段
-Hotzones Table,行人車禍熱區詳細資料
+Hot Zone Name,車禍重災區路段
+Hotzones Table,行人車禍重災區詳細資料

--- a/inst/app/translation/translation_zh.csv
+++ b/inst/app/translation/translation_zh.csv
@@ -8,6 +8,7 @@ Data Download,數據下載
 Project Info,關於此專案
 User Survey,用戶問卷調查
 Filters,篩選分類
+Please use the data filters below to select the category of traffic collisions you would like to show on the map. The map will automatically update and show the collisions meeting the current filter settings.,請利用下列不同種類的數據過濾器選擇你想顯示的車禍。地圖會自動按你現時所選擇的條件更新及顯示符合現有組合之車禍。
 District(s),地區
 From,由（年月）
 To,至（年月）

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -88,7 +88,7 @@ ui <- dashboardPage(
 
       # Pedestrian collision hotzones
       menuItem(
-        text = i18n$t("Pedestrian collision hotzones"),
+        text = i18n$t("Pedestrian Collision Hotzones"),
         icon = icon(name = "exclamation-triangle"),
         tabName = "tab_pedestrian_collision_hotzones"
       ),

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -100,13 +100,6 @@ ui <- dashboardPage(
         tabName = "tab_key_facts"
       ),
 
-      # Data Download
-      menuItem(
-        text = i18n$t("Data Download"),
-        icon = icon(name = "file-download"),
-        tabName = "tab_data_download"
-      ),
-
       # Project Info
       menuItem(
         text = i18n$t("Project Info"),
@@ -490,26 +483,6 @@ ui <- dashboardPage(
             )
           )
         )
-      ),
-
-      # Menu item: Data Download -----------------------------------------------
-
-      tabItem(
-        tabName = "tab_data_download",
-          box(
-            width = 12,
-            title = "Data Source",
-            icon(name = "wrench"),
-            "We are currently finding ways to host the data for download.",
-            icon(name = "hammer"),
-            br(),
-            icon(name = "wrench"),
-            "我們正在尋找不同方法及系統以存放數據。",
-            icon(name = "hammer"),
-            hr(),
-            p("If you are interested in getting the traffic collision data, please contact us."),
-            p("若你有興趣獲取數據，請直接聯絡我們。")
-          )
       ),
 
       # Menu item: Project Info ------------------------------------------------

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -502,8 +502,13 @@ ui <- dashboardPage(
             icon(name = "wrench"),
             "We are currently finding ways to host the data for download.",
             icon(name = "hammer"),
+            br(),
+            icon(name = "wrench"),
+            "我們正在尋找不同方法及系統以存放數據。",
+            icon(name = "hammer"),
             hr(),
             p("If you are interested in getting the traffic collision data, please contact us."),
+            p("若你有興趣獲取數據，請直接聯絡我們。")
           )
       ),
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -22,7 +22,7 @@ ui <- dashboardPage(
                 inputId = "selected_language",
                 label = NULL,
                 choices = setNames(i18n$get_languages(), c("EN", "中")),
-                selected = i18n$get_key_translation(),
+                selected = "zh",
                 status = "dark",
                 size = "xs"
               )

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -439,7 +439,7 @@ ui <- dashboardPage(
         fluidRow(
           box(
             width = 12,
-            title = i18n$t("Pedestrian Collision Hotzones"),
+            title = span(icon("exclamation-triangle"), i18n$t("Pedestrian Collision Hotzones")),
             includeMarkdown("desc/hotzone.md"),
 
             tmapOutput(outputId = "hotzones_map")
@@ -464,7 +464,7 @@ ui <- dashboardPage(
           box(
             width = 12,
 
-            title = span(icon("file-alt"), "Key facts about pedestrian-related collisions"),
+            title = span(icon("file-alt"), i18n$t("Key facts about pedestrian-related collisions")),
             includeMarkdown("desc/key_facts.md"),
 
             column(
@@ -528,8 +528,8 @@ ui <- dashboardPage(
             width = 12,
             # Add icon inside heading
             # https://community.rstudio.com/t/how-to-add-an-icon-in-shinydashboard-box-title/20650
-            title = span(icon("th-list"), "Glossary of Terms"),
-            p("The following terms are used in this website."),
+            title = span(icon("th-list"), i18n$t("Glossary of Terms")),
+            i18n$t("The following terms are used in this website."),
             dataTableOutput(outputId = "terminology_table")
           )
         ),

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -181,6 +181,12 @@ ui <- dashboardPage(
 
               h3(span(icon("filter")), " ", i18n$t("Filters")),
 
+              p(
+                i18n$t("Please use the data filters below to select the category of traffic collisions you would like to show on the map. The map will automatically update and show the collisions meeting the current filter settings."),
+                # add spacing to the first widget
+                style = "margin-bottom: 10px"
+                ),
+
               uiOutput("district_filter_ui"),
 
               uiOutput("start_month_ui"),

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -440,6 +440,8 @@ ui <- dashboardPage(
           box(
             width = 12,
             title = i18n$t("Pedestrian Collision Hotzones"),
+            includeMarkdown("desc/hotzone.md"),
+
             tmapOutput(outputId = "hotzones_map")
           )
         ),


### PR DESCRIPTION
# Summary

This branch completes the traditional Chinese translation of the website (except *District Dashboard* tab).

# Changes

The changes made in this PR are:

1. Set traditional Chinese (*zh*) as the default language of the website
1. Complete traditional Chinese translation to *Key Facts* and *Project Info* tabs
1. Remove the *Data Download* tab until the method of hosting data is resolved
1. Add a description in the collision map filter tab that collision points shown are updated automatically after filters are changed

![main-map](https://user-images.githubusercontent.com/29334677/189726738-2b2c6829-c02f-4efc-a8a3-4e77df7e9d03.png)

![hotzone](https://user-images.githubusercontent.com/29334677/189726729-6bc219a8-70b7-4202-b9e8-53a30b19f131.png)

![key-facts](https://user-images.githubusercontent.com/29334677/189726719-56c259b0-3f4a-466e-bc7f-ae08b731ef26.png)

![project-info](https://user-images.githubusercontent.com/29334677/189726698-9373fa99-fd72-456d-a8d6-9ce1a6eee18e.png)


***

# Check

- [x] (If UI & data are updated) The UI & data includes Traditional Chinese translation, with translation terms wrapped in `i18n$t()` and terms added to `translation_zh.csv`
- [x] The travis.ci and R CMD checks pass.

***

## Note

Both *zh* and *en* versions of the paragraphs in *Key Facts* and *Project Info* are shown regardless of the users' currently selected language. This is because paragraphs of both languages are stored in the same markdown file, then rendered to the website using `includeMarkdown()`.

Showing only the paragraphs of the current language (may) require wrapping the section in `renderUI()`, then splitting the *zh*/*en* paragraphs into separate markdown files. The markdown going to be rendered then depends on the currently selected language.

