### PR TITLE
Feat: Add "Zoom to filtered collision" button

### DIFF
--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -1,6 +1,16 @@
 #############
 ## Filter UI
 #############
+
+observeEvent(input$zoom_to_pts, {
+  data_bbox = st_bbox(filter_collision_data())
+
+  fitBounds(
+    leafletProxy("main_map"),
+    data_bbox[["xmin"]], data_bbox[["ymin"]], data_bbox[["xmax"]], data_bbox[["ymax"]]
+    )
+})
+
 output$district_filter_ui = renderUI({
   selectizeInput(
     inputId = "district_filter",

--- a/inst/app/translation/translation_zh.csv
+++ b/inst/app/translation/translation_zh.csv
@@ -9,6 +9,7 @@ Project Info,關於此專案
 User Survey,用戶問卷調查
 Filters,篩選分類
 Please use the data filters below to select the category of traffic collisions you would like to show on the map. The map will automatically update and show the collisions meeting the current filter settings.,請利用下列不同種類的數據過濾器選擇你想顯示的車禍。地圖會自動按你現時所選擇的條件更新及顯示符合現有組合之車禍。
+Zoom to matched collisions,縮放至合符現有篩選條件之車禍
 District(s),地區
 Date range,日期範圍
 Collision severity,車禍嚴重程度

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -180,6 +180,8 @@ ui <- dashboardPage(
                 style = "margin-bottom: 10px"
                 ),
 
+              actionButton("zoom_to_pts", "Zoom to filtered features"),
+
               uiOutput("district_filter_ui"),
 
               uiOutput("month_range_ui"),

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -181,7 +181,7 @@ ui <- dashboardPage(
                 ),
 
               div(
-                actionButton("zoom_to_pts", label = "Zoom to matched collisions", icon = icon("search-plus")),
+                actionButton("zoom_to_pts", label = i18n$t("Zoom to matched collisions"), icon = icon("search-plus")),
                 style = "display: flex;justify-content: center;align-items: center;margin-bottom: 10px;"
                 ),
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -180,7 +180,10 @@ ui <- dashboardPage(
                 style = "margin-bottom: 10px"
                 ),
 
-              actionButton("zoom_to_pts", "Zoom to filtered features"),
+              div(
+                actionButton("zoom_to_pts", label = "Zoom to matched collisions", icon = icon("search-plus")),
+                style = "display: flex;justify-content: center;align-items: center;margin-bottom: 10px;"
+                ),
 
               uiOutput("district_filter_ui"),
 


### PR DESCRIPTION
# Summary

This branch adds a "Zoom to filtered collision" button in the collision location map (partly addresses and closes #79)

# Changes

The changes made in this PR are:

1. Adds a "Zoom to matched collisions" button in the filter panel. When the user clicks on the button the extent of the map will be reset to the boundary (bounding box) of the currently filtered collision points.

![button-location](https://user-images.githubusercontent.com/29334677/189742805-ed0f3a82-1ca0-4e38-a7f4-0b9bab960209.jpg)

https://user-images.githubusercontent.com/29334677/189742813-95e64697-e026-4de8-91b2-a3f8f2dce721.mp4


***

# Check

- [x] (If UI & data are updated) The UI & data includes Traditional Chinese translation, with translation terms wrapped in `i18n$t()` and terms added to `translation_zh.csv`
- [x] The travis.ci and R CMD checks pass.

***

## Note

`st_bbox()` maybe overkill to find out the boundaries of the currently filtered collisions. Need to benchmark the performance of the website.