### PR TITLE
UI: Set max width for paragraphs

### DIFF
--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -493,9 +493,17 @@ ui <- dashboardPage(
       tabItem(
         tabName = "tab_project_info",
         fluidRow(
-          box(
-            width = 12,
-            includeMarkdown("desc/information.md")
+
+          # align the box to center if screen width is larger than max-width
+          style = "display:flex; justify-content:center;",
+          div(
+            # box do not support custom style, need to warp it in div
+            # 640 for body + 15px*2 for padding
+            style = "max-width:670px !important",
+            box(
+              width = 12,
+              includeMarkdown("desc/information.md")
+            )
           )
         ),
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -456,33 +456,40 @@ ui <- dashboardPage(
       tabItem(
         tabName = "tab_key_facts",
         fluidRow(
+          # align the box to center if screen width is larger than max-width
+          style = "display:flex; justify-content:center;",
 
-          box(
-            width = 12,
+          div(
+            # box do not support custom style, need to warp it in div
+            # 640 for body + 15px*2 for padding
+            style = "max-width:670px !important",
+            box(
+              width = 12,
 
-            title = span(icon("file-alt"), i18n$t("Key facts about pedestrian-related collisions")),
-            includeMarkdown("desc/key_facts.md"),
+              title = span(icon("file-alt"), i18n$t("Key facts about pedestrian-related collisions")),
+              includeMarkdown("desc/key_facts.md"),
 
-            column(
-              width = 6,
-              img(src = "report-cover-chi.jpg", height = "100%", width = "100%")
-            ),
-            column(
-              width = 6,
-              img(src = "summary-chi.jpg", height = "100%", width = "100%")
-            ),
+              column(
+                width = 6,
+                img(src = "report-cover-chi.jpg", height = "100%", width = "100%")
+              ),
+              column(
+                width = 6,
+                img(src = "summary-chi.jpg", height = "100%", width = "100%")
+              ),
 
-            # Workaround to add line spacing between the top two images (Chi version) and bottom two images (Eng version)
-            # FIXME: Investigate how to formally add line breaks between `column` objects
-            p(" ", style = "white-space: pre-wrap"),
+              # Workaround to add line spacing between the top two images (Chi version) and bottom two images (Eng version)
+              # FIXME: Investigate how to formally add line breaks between `column` objects
+              p(" ", style = "white-space: pre-wrap"),
 
-            column(
-              width = 6,
-              img(src = "report-cover-eng.jpg", height = "100%", width = "100%")
-            ),
-            column(
-              width = 6,
-              img(src = "summary-eng.jpg", height = "100%", width = "100%")
+              column(
+                width = 6,
+                img(src = "report-cover-eng.jpg", height = "100%", width = "100%")
+              ),
+              column(
+                width = 6,
+                img(src = "summary-eng.jpg", height = "100%", width = "100%")
+              )
             )
           )
         )

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -438,15 +438,12 @@ ui <- dashboardPage(
             title = span(icon("exclamation-triangle"), i18n$t("Pedestrian Collision Hotzones")),
             includeMarkdown("desc/hotzone.md"),
 
-            tmapOutput(outputId = "hotzones_map")
-          )
-        ),
-        fluidRow(
-          box(
-            width = 12,
-            title = i18n$t("Hotzones Table"),
-            dataTableOutput(outputId = "hotzones_table")
+            tmapOutput(outputId = "hotzones_map"),
 
+            tags$br(),
+            h4(i18n$t("Hotzones Table")),
+
+            dataTableOutput(outputId = "hotzones_table")
           )
         )
       ),

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -438,7 +438,7 @@ ui <- dashboardPage(
             title = span(icon("exclamation-triangle"), i18n$t("Pedestrian Collision Hotzones")),
             includeMarkdown("desc/hotzone.md"),
 
-            tmapOutput(outputId = "hotzones_map"),
+            tmapOutput(outputId = "hotzones_map", height = "50vh"),
 
             tags$br(),
             h4(i18n$t("Hotzones Table")),


### PR DESCRIPTION
# Summary

This branch sets a maximum width for paragraphs inside `box` for an easier reading experience.

# Changes

The changes made in this PR are:

1. Set maximum width (currently 640px) for boxes that include mostly paragraphs. The two major tabs affected are "Project Info" and "Key Facts".

***

# Check

- [ ] (If UI & data are updated) The UI & data includes Traditional Chinese translation, with translation terms wrapped in `i18n$t()` and terms added to `translation_zh.csv`
- [x] The travis.ci and R CMD checks pass.

