### PR TITLE
Fix: Suppress `i18n` warning message when translating road hierarchy

### DIFF
--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -223,9 +223,10 @@ observe({
     tags$br(),
 
     tags$b(i18n$t("Within 70 m of junctions? ")), ifelse(filter_collision_data()$Within_70m, i18n$t("Yes"), i18n$t("No")), tags$br(),
-    # FIXME: Will impose warning messages if `Structure_Type` or `Road_Hierarchy` is NA
     tags$b(i18n$t("Road structure: ")), i18n$t(filter_collision_data()$Structure_Type), tags$br(),
-    tags$b(i18n$t("Road hierarchy: ")), i18n$t(filter_collision_data()$Road_Hierarchy),
+    # Suppress warning message from i18n when `Road_Hierarchy` is NA
+    # TODO: Transform NA to ''?
+    tags$b(i18n$t("Road hierarchy: ")), suppressWarnings(i18n$t(filter_collision_data()$Road_Hierarchy)),
 
     tags$br(),
     tags$br(),


### PR DESCRIPTION
# Summary

This branch suppresses `i18n` warning message when translating road hierarchy with `NA` values.

# Changes

The changes made in this PR are:

1. Suppress the following error when `i18n$t` is used to translate road hierarchy values for the map popup.

```
Warning in private$raw_translate(keyword, translation_language) :
  'NA' translation does not exist.
```

***

# Check

- [x] (If UI & data are updated) The UI & data includes Traditional Chinese translation, with translation terms wrapped in `i18n$t()` and terms added to `translation_zh.csv`
- [x] The travis.ci and R CMD checks pass.

***

## Note

The following code cannot suppress warning message. Maybe caused by the vectorisation execution behaviour of `ifelse`?

```r
    tags$b(i18n$t("Road hierarchy: ")),
    ifelse(is.na(filter_collision_data()$Road_Hierarchy), "N/A", i18n$t(filter_collision_data()$Road_Hierarchy))
```
