### PR TITLE
Feat: Show collisions in all district by default & restrict max no. of points shown on map

### DIFF
--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -20,8 +20,8 @@ output$district_filter_ui = renderUI({
       lapply(DISTRICT_FULL_NAME, function(x) i18n$t(x))
     ),
     multiple = TRUE,
-    selected = c("KC", "YTM", "SSP"),
-    options = list(maxItems = 3, placeholder = 'Select districts (3 maximum)')
+    selected = DISTRICT_ABBR,
+    options = list(placeholder = 'Select districts')
   ) %>%
     shinyhelper::helper(
       type = "markdown", colour = "#0d0d0d",

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -159,6 +159,11 @@ filter_collision_data <-
 
       data_filtered <- filter(data_filtered, Serial_No_ %in% accient_w_selected_veh_vct)
 
+      # Show at most 20,000 points on the map to ensure performance
+      if (nrow(data_filtered) > 20000) {
+        return(data_filtered[1:20000,])
+      }
+
       data_filtered
     })
   )

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -161,6 +161,26 @@ filter_collision_data <-
 
       # Show at most 20,000 points on the map to ensure performance
       if (nrow(data_filtered) > 20000) {
+
+        showNotification(
+          paste(
+            "
+            地圖不能顯示所有符合篩選條件的車禍。
+            此地圖只可以同時顯示最多 20,000 宗車禍，而現有篩選條件包含超過 20,000 宗車禍。
+            地圖只會顯示首 20,000 宗符合條件的車禍。
+            請更改篩選條件（如刪除地區，縮短日期範圍）以顯示所有符合篩選條件之車禍。
+            ",
+            "
+            The map cannot show all collisions matching the requirements.
+            The total number of collisions included in current filter settings exceeds the rendering capacity (20,000 points) of the map.
+            Only the first 20,000 records are shown on the map.
+            Change the filters (e.g. remove districts outside your area of interest, shortern the time frame) to show all filtered records.
+            "
+            , collapse = "<br/>"),
+          type = "error",
+          duration = NULL,
+        )
+
         return(data_filtered[1:20000,])
       }
 


### PR DESCRIPTION
# Summary

This branch shows collisions in all district by default & restrict max no. of points shown on the map.

# Changes

The changes made in this PR are:

1. Show collisions in all districts by default. Originally, only Kowloon City (KC), Yau Tsim Mong (YTM) and Shum Shui Po (SSP) are selected in the district filter. 
    ![full-updated-view](https://user-images.githubusercontent.com/29334677/200205410-5cae157b-0ca1-47f8-bebb-01282f60088f.jpg)

1. Restrict the maximum number of points returned from the filters to **20,000**.
1. Show a warning/error message when the number of records filtered exceeds 20,000.

    ![exceed-error-message](https://user-images.githubusercontent.com/29334677/200205431-7eabca08-a34e-48b0-93c3-62630b3042b8.jpg)


***

# Check


- [x] (If UI & data are updated) The UI & data includes Traditional Chinese translation, with translation terms wrapped in `i18n$t()` and terms added to `translation_zh.csv`
- [x] The travis.ci and R CMD checks pass.

***

## Note

A better warning/error message should be designed, like [changing colour](https://stackoverflow.com/questions/60618714/change-color-of-notification-in-r-shiny) and [line breaks](https://stackoverflow.com/questions/46290869/how-to-break-line-in-long-shownotification-for-rshiny) between Chi and Eng message.
