### PR TITLE
Feat: Simplify collision by-year trend graph

### DIFF
--- a/inst/app/modules/district_dsb_all.R
+++ b/inst/app/modules/district_dsb_all.R
@@ -147,16 +147,9 @@ output$ddsb_all_ksi_plot = renderPlotly({
 # Collision by year plot
 output$ddsb_all_year_plot = renderPlotly({
 
-  selected_district_data = filter(hk_accidents, District_Council_District == input$ddsb_district_filter)
-
-  year_min = input$ddsb_year_filter[1]
-  year_max = input$ddsb_year_filter[2]
-
   plot_data = count(ddsb_filtered_hk_accidents(), Year, name = "count", na.rm = TRUE)
 
   collision_year_trend_plot = ggplot(plot_data, aes(x = Year, y = count)) +
-    # ggplotly does not support `ymin = -Inf, ymax = Inf`
-    annotate("rect", xmin = year_min, xmax = year_max, ymin = 0, ymax = max(plot_data$count), alpha = .2, fill = "red") +
     geom_line() +
     theme_minimal() +
     theme(
@@ -168,13 +161,7 @@ output$ddsb_all_year_plot = renderPlotly({
       title = "Trend of collision in selected district"
     )
 
-  out_plot = ggplotly(collision_year_trend_plot)
-
-  # Disable tooltip of the annotation geom
-  # https://stackoverflow.com/questions/45801389/disable-hover-information-for-a-specific-layer-geom-of-plotly
-  out_plot$x$data[[1]]$hoverinfo <- "none"
-
-  out_plot
+  ggplotly(collision_year_trend_plot)
 
 })
 

--- a/inst/app/modules/district_dsb_all.R
+++ b/inst/app/modules/district_dsb_all.R
@@ -152,7 +152,7 @@ output$ddsb_all_year_plot = renderPlotly({
   year_min = input$ddsb_year_filter[1]
   year_max = input$ddsb_year_filter[2]
 
-  plot_data = count(selected_district_data, Year, name = "count", na.rm = TRUE)
+  plot_data = count(ddsb_filtered_hk_accidents(), Year, name = "count", na.rm = TRUE)
 
   collision_year_trend_plot = ggplot(plot_data, aes(x = Year, y = count)) +
     # ggplotly does not support `ymin = -Inf, ymax = Inf`


### PR DESCRIPTION
# Summary

This branch simplifies the year trend graph of the total number of collisions in the dashboard. 

# Changes

The changes made in this PR are:

1. Simplify the collision number year trend graph by:
    1. Showing only years within the selected year range
    2. Remove the background annotation showing the selected year range
1. Directly use the filtered dataset from the reactive expression `ddsb_filtered_hk_accidents()`. Previously, the chart filters the dataset again in order to show the numbers of all covered years. For example, when the users choose the year range from 2015-2018, the year trend line still covers all years from 2014 to 2019.

### After

![after](https://user-images.githubusercontent.com/29334677/202908398-68ff76f8-512b-4013-960b-9ef87ab0d59e.jpg)


### Before

![before](https://user-images.githubusercontent.com/29334677/202908389-df64f49c-9aeb-478b-a2e2-d2138dd8be5b.jpg)


***

# Check

- [x] (If UI & data are updated) The UI & data includes Traditional Chinese translation, with translation terms wrapped in `i18n$t()` and terms added to `translation_zh.csv`
- [x] The travis.ci and R CMD checks pass.

