### PR TITLE
i18n: Add translation of control options of dashboards

### DIFF
--- a/inst/app/modules/district_dsb.R
+++ b/inst/app/modules/district_dsb.R
@@ -14,7 +14,10 @@ output$dsb_filter_ui = renderUI({
 output$ksi_filter_ui = renderUI({
   selectInput(
     inputId = "ddsb_ksi_filter", label = "Select collision severity category",
-    choices = c("All", "Killed or Seriously Injuries only"),
+    choices = setNames(
+      c("all", "ksi_only"),
+      c("All", "Killed or Seriously Injuries only")
+      ),
     selected = "all"
   )
 })
@@ -31,7 +34,7 @@ ddsb_filtered_hk_accidents = reactive({
   hk_accidents_filtered = filter(hk_accidents_filtered, Year >= input$ddsb_year_filter[1] & Year <= input$ddsb_year_filter[2])
 
   # remove slightly injured collisions if user select "KSI only" option
-  if (input$ddsb_ksi_filter == "Killed or Seriously Injuries only") {
+  if (ddsb_ksi_filter == "ksi_only") {
     hk_accidents_filtered = filter(hk_accidents_filtered, Severity != "Slight")
   }
 

--- a/inst/app/modules/district_dsb.R
+++ b/inst/app/modules/district_dsb.R
@@ -16,7 +16,7 @@ output$ksi_filter_ui = renderUI({
     inputId = "ddsb_ksi_filter", label = "Select collision severity category",
     choices = setNames(
       c("all", "ksi_only"),
-      c("All", "Killed or Seriously Injuries only")
+      c(i18n$t("All Severities"), i18n$t("Killed or Seriously Injuries only"))
       ),
     selected = "all"
   )

--- a/inst/app/modules/district_dsb.R
+++ b/inst/app/modules/district_dsb.R
@@ -10,3 +10,30 @@ output$dsb_filter_ui = renderUI({
     selected = "CW"
   )
 })
+
+
+# Return filtered hk_accidents dataframe according to users' selected inputs
+ddsb_filtered_hk_accidents = reactive({
+  # filter by users' selected district
+  # FIXME: Temp workaround to fix non-initialised value when district filter renders in server side
+  ddsb_district_filter = if (is.null(input$ddsb_district_filter)) "CW" else input$ddsb_district_filter
+  hk_accidents_filtered = filter(hk_accidents, District_Council_District == ddsb_district_filter)
+
+  # filter by users' selected time range
+  hk_accidents_filtered = filter(hk_accidents_filtered, Year >= input$ddsb_year_filter[1] & Year <= input$ddsb_year_filter[2])
+
+  # remove slightly injured collisions if user select "KSI only" option
+  if (input$ddsb_ksi_filter == "Killed or Seriously Injuries only") {
+    hk_accidents_filtered = filter(hk_accidents_filtered, Severity != "Slight")
+  }
+
+  # Show only collisions with valid lng/lat
+  hk_accidents_filtered = hk_accidents_filtered %>%
+    filter(!is.na(Grid_E) & !is.na(Grid_N)) %>%
+    st_as_sf(coords = c("Grid_E", "Grid_N"), crs = 2326, remove = FALSE)
+
+  print(nrow(hk_accidents_filtered))
+
+  hk_accidents_filtered
+
+})

--- a/inst/app/modules/district_dsb.R
+++ b/inst/app/modules/district_dsb.R
@@ -2,7 +2,7 @@
 
 output$dsb_filter_ui = renderUI({
   selectInput(
-    inputId = "ddsb_district_filter", label = "Select District",
+    inputId = "ddsb_district_filter", label = i18n$t("Select District"),
     choices = stats::setNames(
       DISTRICT_ABBR,
       lapply(DISTRICT_FULL_NAME, function(x) i18n$t(x))
@@ -13,7 +13,7 @@ output$dsb_filter_ui = renderUI({
 
 output$ksi_filter_ui = renderUI({
   selectInput(
-    inputId = "ddsb_ksi_filter", label = "Select collision severity category",
+    inputId = "ddsb_ksi_filter", label = i18n$t("Select collision severity category"),
     choices = setNames(
       c("all", "ksi_only"),
       c(i18n$t("All Severities"), i18n$t("Killed or Seriously Injuries only"))

--- a/inst/app/modules/district_dsb.R
+++ b/inst/app/modules/district_dsb.R
@@ -11,6 +11,14 @@ output$dsb_filter_ui = renderUI({
   )
 })
 
+output$ksi_filter_ui = renderUI({
+  selectInput(
+    inputId = "ddsb_ksi_filter", label = "Select collision severity category",
+    choices = c("All", "Killed or Seriously Injuries only"),
+    selected = "all"
+  )
+})
+
 
 # Return filtered hk_accidents dataframe according to users' selected inputs
 ddsb_filtered_hk_accidents = reactive({

--- a/inst/app/modules/district_dsb.R
+++ b/inst/app/modules/district_dsb.R
@@ -1,1 +1,12 @@
 # Fundamental reactive functions and UI for the district dashboard
+
+output$dsb_filter_ui = renderUI({
+  selectInput(
+    inputId = "ddsb_district_filter", label = "Select District",
+    choices = stats::setNames(
+      DISTRICT_ABBR,
+      lapply(DISTRICT_FULL_NAME, function(x) i18n$t(x))
+    ),
+    selected = "CW"
+  )
+})

--- a/inst/app/modules/district_dsb.R
+++ b/inst/app/modules/district_dsb.R
@@ -1,0 +1,1 @@
+# Fundamental reactive functions and UI for the district dashboard

--- a/inst/app/modules/district_dsb.R
+++ b/inst/app/modules/district_dsb.R
@@ -34,6 +34,9 @@ ddsb_filtered_hk_accidents = reactive({
   hk_accidents_filtered = filter(hk_accidents_filtered, Year >= input$ddsb_year_filter[1] & Year <= input$ddsb_year_filter[2])
 
   # remove slightly injured collisions if user select "KSI only" option
+  # FIXME: Temp workaround to fix non-initialised value when KSI filter renders in server side
+  ddsb_ksi_filter = if (is.null(input$ddsb_ksi_filter)) "all" else input$ddsb_ksi_filter
+
   if (ddsb_ksi_filter == "ksi_only") {
     hk_accidents_filtered = filter(hk_accidents_filtered, Severity != "Slight")
   }

--- a/inst/app/modules/district_dsb_all.R
+++ b/inst/app/modules/district_dsb_all.R
@@ -4,7 +4,9 @@
 # Return filtered hk_accidents dataframe according to users' selected inputs
 ddsb_filtered_hk_accidents = reactive({
   # filter by users' selected district
-  hk_accidents_filtered = filter(hk_accidents, District_Council_District == input$ddsb_district_filter)
+  # FIXME: Temp workaround to fix non-initialised value when district filter renders in server side
+  ddsb_district_filter = if (is.null(input$ddsb_district_filter)) "CW" else input$ddsb_district_filter
+  hk_accidents_filtered = filter(hk_accidents, District_Council_District == ddsb_district_filter)
 
   # filter by users' selected time range
   hk_accidents_filtered = filter(hk_accidents_filtered, Year >= input$ddsb_year_filter[1] & Year <= input$ddsb_year_filter[2])

--- a/inst/app/modules/district_dsb_all.R
+++ b/inst/app/modules/district_dsb_all.R
@@ -1,32 +1,6 @@
 # For filtering the dataset according to users' input filter
 # and visualise the dataset in the "all collisions" tab
 
-# Return filtered hk_accidents dataframe according to users' selected inputs
-ddsb_filtered_hk_accidents = reactive({
-  # filter by users' selected district
-  # FIXME: Temp workaround to fix non-initialised value when district filter renders in server side
-  ddsb_district_filter = if (is.null(input$ddsb_district_filter)) "CW" else input$ddsb_district_filter
-  hk_accidents_filtered = filter(hk_accidents, District_Council_District == ddsb_district_filter)
-
-  # filter by users' selected time range
-  hk_accidents_filtered = filter(hk_accidents_filtered, Year >= input$ddsb_year_filter[1] & Year <= input$ddsb_year_filter[2])
-
-  # remove slightly injured collisions if user select "KSI only" option
-  if (input$ddsb_ksi_filter == "Killed or Seriously Injuries only") {
-    hk_accidents_filtered = filter(hk_accidents_filtered, Severity != "Slight")
-  }
-
-  # Show only collisions with valid lng/lat
-  hk_accidents_filtered = hk_accidents_filtered %>%
-    filter(!is.na(Grid_E) & !is.na(Grid_N)) %>%
-    st_as_sf(coords = c("Grid_E", "Grid_N"), crs = 2326, remove = FALSE)
-
-  print(nrow(hk_accidents_filtered))
-
-  hk_accidents_filtered
-
-})
-
 # filtered hk_casualties
 ddsb_filtered_hk_casualties = reactive({
 

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -34,6 +34,7 @@ server <- function(input, output, session) {
 
 
   # ----- TAB: Dashboard ----- #
+  source(file = "modules/district_dsb.R", local = TRUE)
   source(file = "modules/district_dsb_all.R", local = TRUE)
   source(file = "modules/district_dsb_ped.R", local = TRUE)
   source(file = "modules/district_dsb_cyc.R", local = TRUE)

--- a/inst/app/translation/translation_zh.csv
+++ b/inst/app/translation/translation_zh.csv
@@ -92,6 +92,8 @@ Within 70 m of junctions? ,位處路口 70 米內？
 Yes,是
 No,否
 View this location in Google Street View,於 Google 街景顯示此車禍位置
+All Severities, 所有嚴重程度
+Killed or Seriously Injuries only, 只包含重傷或致命車禍
 Hotzone streets,車禍重災區路段
 Hotzone Rank,重災區排名
 Collisions with pedestrian injuries,涉及行人傷亡車禍地點

--- a/inst/app/translation/translation_zh.csv
+++ b/inst/app/translation/translation_zh.csv
@@ -92,6 +92,12 @@ Within 70 m of junctions? ,位處路口 70 米內？
 Yes,是
 No,否
 View this location in Google Street View,於 Google 街景顯示此車禍位置
+Area Filter, 地區
+Select District, 選擇地區
+Year Filter, 年份範圍
+Select time period, 選擇年份範圍
+All/ KSI Filter, 車禍嚴重程度
+Select collision severity category, 選擇車禍嚴重程度
 All Severities, 所有嚴重程度
 Killed or Seriously Injuries only, 只包含重傷或致命車禍
 Hotzone streets,車禍重災區路段

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -214,10 +214,7 @@ ui <- dashboardPage(
           box(
             width = 4,
             title = "Area Filter",
-            selectInput(
-              inputId = "ddsb_district_filter", label = "Select District",
-              choices = setNames(DISTRICT_ABBR, DISTRICT_FULL_NAME)
-            )
+            uiOutput("dsb_filter_ui")
           ),
           box(
             width = 4,

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -213,14 +213,14 @@ ui <- dashboardPage(
         fluidRow(
           box(
             width = 4,
-            title = "Area Filter",
+            title = i18n$t("Area Filter"),
             uiOutput("dsb_filter_ui")
           ),
           box(
             width = 4,
-            title = "Year Filter",
+            title = i18n$t("Year Filter"),
             sliderInput(
-              inputId =  "ddsb_year_filter", label = "Select time period:",
+              inputId =  "ddsb_year_filter", label = i18n$t("Select time period"),
               min = 2014, max = 2019,
               value = c(2015, 2019),
               # Remove thousands separator
@@ -229,7 +229,7 @@ ui <- dashboardPage(
           ),
           box(
             width = 4,
-            title = "All/ KSI Filter",
+            title = i18n$t("All/ KSI Filter"),
             uiOutput("ksi_filter_ui")
           )
         ),

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -230,10 +230,7 @@ ui <- dashboardPage(
           box(
             width = 4,
             title = "All/ KSI Filter",
-            selectInput(
-              inputId = "ddsb_ksi_filter", label = "Select collision severity category",
-              choices = c("All", "Killed or Seriously Injuries only")
-            )
+            uiOutput("ksi_filter_ui")
           )
         ),
 


### PR DESCRIPTION
# Summary

This branch adds traditional Chinese live translation to the control options of dashboards.

# Changes

The changes made in this PR are:

1. Add an overarching module file (`district_dsb.R`) to store the fundamental reactive expressions and UI for the dashboard
2. Add traditional Chinese live translation to the options available for control collisions shown on dashboard, including:
    1. District
    2. Year range
    3. Collision Severity

### After

![options-after](https://user-images.githubusercontent.com/29334677/202909251-071fbf86-0f8e-4b85-8882-1031a9da2da6.png)


### Before

![options-before](https://user-images.githubusercontent.com/29334677/202909256-b9c47502-96ca-4236-8384-e353e9dc3779.png)

***

# Check

- [x] (If UI & data are updated) The UI & data includes Traditional Chinese translation, with translation terms wrapped in `i18n$t()` and terms added to `translation_zh.csv`
- [x] The travis.ci and R CMD checks pass.

