### PR TITLE
Feat: Revise dashboard options UI

### DIFF
--- a/inst/app/modules/district_dsb.R
+++ b/inst/app/modules/district_dsb.R
@@ -2,7 +2,7 @@
 
 output$dsb_filter_ui = renderUI({
   selectInput(
-    inputId = "ddsb_district_filter", label = i18n$t("Select District"),
+    inputId = "ddsb_district_filter", label = i18n$t("District"),
     choices = stats::setNames(
       DISTRICT_ABBR,
       lapply(DISTRICT_FULL_NAME, function(x) i18n$t(x))
@@ -13,7 +13,7 @@ output$dsb_filter_ui = renderUI({
 
 output$ksi_filter_ui = renderUI({
   selectInput(
-    inputId = "ddsb_ksi_filter", label = i18n$t("Select collision severity category"),
+    inputId = "ddsb_ksi_filter", label = i18n$t("Collision severity"),
     choices = setNames(
       c("all", "ksi_only"),
       c(i18n$t("All Severities"), i18n$t("Killed or Seriously Injuries only"))

--- a/inst/app/translation/translation_zh.csv
+++ b/inst/app/translation/translation_zh.csv
@@ -93,6 +93,7 @@ Yes,是
 No,否
 View this location in Google Street View,於 Google 街景顯示此車禍位置
 District Dashboard, 地區儀表版
+Select collisions to be summarised, 請選擇用以概述之車禍數據
 Area Filter, 地區
 Select District, 選擇地區
 Year Filter, 年份範圍

--- a/inst/app/translation/translation_zh.csv
+++ b/inst/app/translation/translation_zh.csv
@@ -92,6 +92,7 @@ Within 70 m of junctions? ,位處路口 70 米內？
 Yes,是
 No,否
 View this location in Google Street View,於 Google 街景顯示此車禍位置
+District Dashboard, 地區儀表版
 Area Filter, 地區
 Select District, 選擇地區
 Year Filter, 年份範圍

--- a/inst/app/translation/translation_zh.csv
+++ b/inst/app/translation/translation_zh.csv
@@ -94,12 +94,8 @@ No,否
 View this location in Google Street View,於 Google 街景顯示此車禍位置
 District Dashboard, 地區儀表版
 Select collisions to be summarised, 請選擇用以概述之車禍數據
-Area Filter, 地區
-Select District, 選擇地區
-Year Filter, 年份範圍
-Select time period, 選擇年份範圍
-All/ KSI Filter, 車禍嚴重程度
-Select collision severity category, 選擇車禍嚴重程度
+District, 地區
+Year Range, 年份範圍
 All Severities, 所有嚴重程度
 Killed or Seriously Injuries only, 只包含重傷或致命車禍
 Hotzone streets,車禍重災區路段

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -219,15 +219,13 @@ ui <- dashboardPage(
 
             column(
               width = 4,
-              title = i18n$t("Area Filter"),
               uiOutput("dsb_filter_ui")
             ),
 
             column(
               width = 4,
-              title = i18n$t("Year Filter"),
               sliderInput(
-                inputId =  "ddsb_year_filter", label = i18n$t("Select time period"),
+                inputId =  "ddsb_year_filter", label = i18n$t("Year Range"),
                 min = 2014, max = 2019,
                 value = c(2015, 2019),
                 # Remove thousands separator
@@ -237,7 +235,6 @@ ui <- dashboardPage(
 
             column(
               width = 4,
-              title = i18n$t("All/ KSI Filter"),
               uiOutput("ksi_filter_ui")
             )
           )

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -212,25 +212,31 @@ ui <- dashboardPage(
         # Filters
         fluidRow(
           box(
-            width = 4,
-            title = i18n$t("Area Filter"),
-            uiOutput("dsb_filter_ui")
-          ),
-          box(
-            width = 4,
-            title = i18n$t("Year Filter"),
-            sliderInput(
-              inputId =  "ddsb_year_filter", label = i18n$t("Select time period"),
-              min = 2014, max = 2019,
-              value = c(2015, 2019),
-              # Remove thousands separator
-              sep = ""
+            width = 12,
+
+            column(
+              width = 4,
+              title = i18n$t("Area Filter"),
+              uiOutput("dsb_filter_ui")
+            ),
+
+            column(
+              width = 4,
+              title = i18n$t("Year Filter"),
+              sliderInput(
+                inputId =  "ddsb_year_filter", label = i18n$t("Select time period"),
+                min = 2014, max = 2019,
+                value = c(2015, 2019),
+                # Remove thousands separator
+                sep = ""
+              )
+            ),
+
+            column(
+              width = 4,
+              title = i18n$t("All/ KSI Filter"),
+              uiOutput("ksi_filter_ui")
             )
-          ),
-          box(
-            width = 4,
-            title = i18n$t("All/ KSI Filter"),
-            uiOutput("ksi_filter_ui")
           )
         ),
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -215,6 +215,8 @@ ui <- dashboardPage(
             width = 12,
             title = span(icon("tachometer-alt"), i18n$t("District Dashboard")),
 
+            h4(i18n$t("Select collisions to be summarised")),
+
             column(
               width = 4,
               title = i18n$t("Area Filter"),

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -213,6 +213,7 @@ ui <- dashboardPage(
         fluidRow(
           box(
             width = 12,
+            title = span(icon("tachometer-alt"), i18n$t("District Dashboard")),
 
             column(
               width = 4,


### PR DESCRIPTION
# Summary

This branch revises the UI for users to choose different options of the dashboard.

# Changes

The changes made in this PR are:

1. Unify the height of the three option widgets (District, Year range and Killed/Seriously Injured (KSI)) by merging them into a single `box` with same column width.
2. Add tab title (Dashboard).
3. Reverse space for adding the description of the page and usage of the options.

### After

![ui-after](https://user-images.githubusercontent.com/29334677/203234517-c6513cc9-ce6f-434c-ae02-faf98323b099.png)

### Before

![ui-before](https://user-images.githubusercontent.com/29334677/203234512-59cfbb47-5586-4e8c-8135-d5c0bd2ee6f2.png)


***

# Check

- [x] (If UI & data are updated) The UI & data includes Traditional Chinese translation, with translation terms wrapped in `i18n$t()` and terms added to `translation_zh.csv`
- [x] The travis.ci and R CMD checks pass.

