### PR TITLE
Feat: Show individual collisions at zoom lv 15

### DIFF
--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -304,7 +304,7 @@ observe({
       fillColor = ~ fill_palette(Severity), fillOpacity = .9,
       popup = popup_template,
       clusterOptions = markerClusterOptions(
-        disableClusteringAtZoom = 16
+        disableClusteringAtZoom = 15
       )
     )
 })


### PR DESCRIPTION
# Summary

This branch keeps the collision map showing individual collision points at zoom level 15 (district level, ~1:20,000).

# Changes

The changes made in this PR are:

1. Decreases the zoom level for the point clusters from 16 to 15.

### Changes - Showing individual points at zoom level 15

![zoom-15-non-cluster](https://user-images.githubusercontent.com/29334677/226141308-0cd901a2-0268-4d86-8ad6-4afb985867d0.png)

### Original - Points clustered at zoom level 15

![zoom-15-with-cluster](https://user-images.githubusercontent.com/29334677/226141360-4585699d-84a8-46cb-9b86-f5c81d661af4.png)

***

# Check

- [x] (If UI & data are updated) The UI & data includes Traditional Chinese translation, with translation terms wrapped in `i18n$t()` and terms added to `translation_zh.csv`
- [x] The travis.ci and R CMD checks pass.

