### PR TITLE
Feat: Use Stamen TonerLite as the default basemap

### DIFF
--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -73,7 +73,7 @@ hotzone_out_df = fst::read_fst("./data/data-manipulated/hotzone_out_df.fst")
 # interactive thematic map mode option ------------------------------------
 
 # Subset basemap providers to be used for interactive maps
-SELECTED_BASEMAPS = c("CartoDB.Positron", "OpenStreetMap", "Stamen.TonerLite")
+SELECTED_BASEMAPS = c("Stamen.TonerLite", "OpenStreetMap", "CartoDB.Positron")
 
 tmap_mode("view")
 tmap_options(basemaps = SELECTED_BASEMAPS)

--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -73,7 +73,7 @@ hotzone_out_df = fst::read_fst("./data/data-manipulated/hotzone_out_df.fst")
 # interactive thematic map mode option ------------------------------------
 
 # Subset basemap providers to be used for interactive maps
-SELECTED_BASEMAPS = c("Stamen.TonerLite", "OpenStreetMap", "CartoDB.Positron")
+SELECTED_BASEMAPS = c("Stadia.StamenTonerLite", "OpenStreetMap", "CartoDB.Positron")
 
 tmap_mode("view")
 tmap_options(basemaps = SELECTED_BASEMAPS)

--- a/renv.lock
+++ b/renv.lock
@@ -14,15 +14,17 @@
       "Version": "1.81.0-1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "68122010f01c4dcfbe58ce7112f2433d",
-      "Requirements": []
+      "Hash": "68122010f01c4dcfbe58ce7112f2433d"
     },
     "DBI": {
       "Package": "DBI",
       "Version": "1.1.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "methods"
+      ],
       "Hash": "b2866e62bab9378c3cc9476a1954226b"
     },
     "DT": {
@@ -30,7 +32,15 @@
       "Version": "0.28",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "crosstalk",
+        "htmltools",
+        "htmlwidgets",
+        "jquerylib",
+        "jsonlite",
+        "magrittr",
+        "promises"
+      ],
       "Hash": "ab745834dfae7eaf71dd0b90f3b66759"
     },
     "KernSmooth": {
@@ -38,7 +48,10 @@
       "Version": "2.23-20",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "stats"
+      ],
       "Hash": "8dcfa99b14c296bc9f1fd64d52fd3ce7"
     },
     "MASS": {
@@ -46,7 +59,14 @@
       "Version": "7.3-60",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "grDevices",
+        "graphics",
+        "methods",
+        "stats",
+        "utils"
+      ],
       "Hash": "a56a6365b3fa73293ea8d084be0d9bb0"
     },
     "Matrix": {
@@ -54,7 +74,15 @@
       "Version": "1.5-4.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "graphics",
+        "grid",
+        "lattice",
+        "methods",
+        "stats",
+        "utils"
+      ],
       "Hash": "38082d362d317745fb932e13956dccbb"
     },
     "R6": {
@@ -62,7 +90,9 @@
       "Version": "2.5.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R"
+      ],
       "Hash": "470851b6d5d0ac559e9d01bb352b4021"
     },
     "RColorBrewer": {
@@ -70,7 +100,9 @@
       "Version": "1.1-3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R"
+      ],
       "Hash": "45f0398006e83a5b10b72a90663d8d8c"
     },
     "Rcpp": {
@@ -78,7 +110,10 @@
       "Version": "1.0.10",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "methods",
+        "utils"
+      ],
       "Hash": "e749cae40fa9ef469b6050959517453c"
     },
     "XML": {
@@ -86,7 +121,11 @@
       "Version": "3.99-0.14",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "methods",
+        "utils"
+      ],
       "Hash": "e5c8af79df616c135b21eaeb1dc6bc5c"
     },
     "abind": {
@@ -94,7 +133,11 @@
       "Version": "1.4-5",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "methods",
+        "utils"
+      ],
       "Hash": "4f57884290cc75ab22f4af9e9d4ca862"
     },
     "anytime": {
@@ -102,7 +145,11 @@
       "Version": "0.3.9",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "BH",
+        "R",
+        "Rcpp"
+      ],
       "Hash": "74a64813f17b492da9c6afda6b128e3d"
     },
     "askpass": {
@@ -110,7 +157,9 @@
       "Version": "1.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "sys"
+      ],
       "Hash": "e8a22846fff485f0be3770c2da758713"
     },
     "base64enc": {
@@ -118,7 +167,9 @@
       "Version": "0.1-3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R"
+      ],
       "Hash": "543776ae6848fde2f48ff3816d0628bc"
     },
     "bslib": {
@@ -126,7 +177,19 @@
       "Version": "0.5.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "base64enc",
+        "cachem",
+        "grDevices",
+        "htmltools",
+        "jquerylib",
+        "jsonlite",
+        "memoise",
+        "mime",
+        "rlang",
+        "sass"
+      ],
       "Hash": "1b117970533deb6d4e992c1b34e9d905"
     },
     "cachem": {
@@ -134,7 +197,10 @@
       "Version": "1.0.8",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "fastmap",
+        "rlang"
+      ],
       "Hash": "c35768291560ce302c0a6589f92e837d"
     },
     "class": {
@@ -142,7 +208,12 @@
       "Version": "7.3-22",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "MASS",
+        "R",
+        "stats",
+        "utils"
+      ],
       "Hash": "f91f6b29f38b8c280f2b9477787d4bb2"
     },
     "classInt": {
@@ -150,7 +221,15 @@
       "Version": "0.4-9",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "KernSmooth",
+        "R",
+        "class",
+        "e1071",
+        "grDevices",
+        "graphics",
+        "stats"
+      ],
       "Hash": "bee651a42a89633eccb36dca9d9ab413"
     },
     "cli": {
@@ -158,7 +237,10 @@
       "Version": "3.6.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "utils"
+      ],
       "Hash": "89e6d8219950eac806ae0c489052048a"
     },
     "colorspace": {
@@ -166,7 +248,13 @@
       "Version": "2.1-0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "grDevices",
+        "graphics",
+        "methods",
+        "stats"
+      ],
       "Hash": "f20c47fd52fae58b4e377c37bb8c335b"
     },
     "commonmark": {
@@ -174,23 +262,25 @@
       "Version": "1.9.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "d691c61bff84bd63c383874d2d0c3307",
-      "Requirements": []
+      "Hash": "d691c61bff84bd63c383874d2d0c3307"
     },
     "cpp11": {
       "Package": "cpp11",
       "Version": "0.4.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "3f7d8664d7324406cd10cd650ad85e5f",
-      "Requirements": []
+      "Hash": "3f7d8664d7324406cd10cd650ad85e5f"
     },
     "crayon": {
       "Package": "crayon",
       "Version": "1.5.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "grDevices",
+        "methods",
+        "utils"
+      ],
       "Hash": "e8a1e41acf02548751f45c718d55aa6a"
     },
     "crosstalk": {
@@ -198,7 +288,12 @@
       "Version": "1.2.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R6",
+        "htmltools",
+        "jsonlite",
+        "lazyeval"
+      ],
       "Hash": "6aa54f69598c32177e920eb3402e8293"
     },
     "curl": {
@@ -206,7 +301,9 @@
       "Version": "5.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R"
+      ],
       "Hash": "2118af9cb164c8d2dddc7b89eaf732d9"
     },
     "data.table": {
@@ -214,7 +311,10 @@
       "Version": "1.14.8",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "methods"
+      ],
       "Hash": "b4c06e554f33344e044ccd7fdca750a9"
     },
     "dichromat": {
@@ -222,7 +322,10 @@
       "Version": "2.0-0.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "stats"
+      ],
       "Hash": "16e66f2a483e124af5fc6582d26005f7"
     },
     "digest": {
@@ -230,7 +333,10 @@
       "Version": "0.6.31",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "utils"
+      ],
       "Hash": "8b708f296afd9ae69f450f9640be8990"
     },
     "dplyr": {
@@ -238,7 +344,22 @@
       "Version": "1.1.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "R6",
+        "cli",
+        "generics",
+        "glue",
+        "lifecycle",
+        "magrittr",
+        "methods",
+        "pillar",
+        "rlang",
+        "tibble",
+        "tidyselect",
+        "utils",
+        "vctrs"
+      ],
       "Hash": "dea6970ff715ca541c387de363ff405e"
     },
     "e1071": {
@@ -246,7 +367,15 @@
       "Version": "1.7-13",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "class",
+        "grDevices",
+        "graphics",
+        "methods",
+        "proxy",
+        "stats",
+        "utils"
+      ],
       "Hash": "1046cb48d06cb40c2900d8878f03a0fe"
     },
     "ellipsis": {
@@ -254,7 +383,10 @@
       "Version": "0.3.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "rlang"
+      ],
       "Hash": "bb0eec2fe32e88d9e2836c2f73ea2077"
     },
     "evaluate": {
@@ -262,7 +394,10 @@
       "Version": "0.21",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "methods"
+      ],
       "Hash": "d59f3b464e8da1aef82dc04b588b8dfb"
     },
     "fansi": {
@@ -270,7 +405,11 @@
       "Version": "1.0.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "grDevices",
+        "utils"
+      ],
       "Hash": "1d9e7ad3c8312a192dea7d3db0274fde"
     },
     "farver": {
@@ -278,23 +417,25 @@
       "Version": "2.1.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "8106d78941f34855c440ddb946b8f7a5",
-      "Requirements": []
+      "Hash": "8106d78941f34855c440ddb946b8f7a5"
     },
     "fastmap": {
       "Package": "fastmap",
       "Version": "1.1.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "f7736a18de97dea803bde0a2daaafb27",
-      "Requirements": []
+      "Hash": "f7736a18de97dea803bde0a2daaafb27"
     },
     "fontawesome": {
       "Package": "fontawesome",
       "Version": "0.5.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "htmltools",
+        "rlang"
+      ],
       "Hash": "1e22b8cabbad1eae951a75e9f8b52378"
     },
     "fs": {
@@ -302,7 +443,10 @@
       "Version": "1.6.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "methods"
+      ],
       "Hash": "94af08e0aa9675a16fadbb3aaaa90d2a"
     },
     "fst": {
@@ -310,7 +454,11 @@
       "Version": "0.9.8",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "Rcpp",
+        "fstcore"
+      ],
       "Hash": "34637e000c63c3de8d8aafceb82fd082"
     },
     "fstcore": {
@@ -318,7 +466,10 @@
       "Version": "0.9.14",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "Rcpp"
+      ],
       "Hash": "4b8819aaa8d1ce9b0f999d23ad24f96b"
     },
     "generics": {
@@ -326,7 +477,10 @@
       "Version": "0.1.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "methods"
+      ],
       "Hash": "15e9634c0fcd294799e9b2e929ed1b86"
     },
     "geojsonsf": {
@@ -334,7 +488,14 @@
       "Version": "2.0.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "Rcpp",
+        "geometries",
+        "jsonify",
+        "rapidjsonr",
+        "sfheaders"
+      ],
       "Hash": "8d077646c6713838233e8710910ef92e"
     },
     "geometries": {
@@ -342,7 +503,9 @@
       "Version": "0.2.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "Rcpp"
+      ],
       "Hash": "122e8341ead01f3746dd312ecc5ffd28"
     },
     "ggplot2": {
@@ -350,7 +513,24 @@
       "Version": "3.4.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "MASS",
+        "R",
+        "cli",
+        "glue",
+        "grDevices",
+        "grid",
+        "gtable",
+        "isoband",
+        "lifecycle",
+        "mgcv",
+        "rlang",
+        "scales",
+        "stats",
+        "tibble",
+        "vctrs",
+        "withr"
+      ],
       "Hash": "3a147ee02e85a8941aad9909f1b43b7b"
     },
     "glue": {
@@ -358,7 +538,10 @@
       "Version": "1.6.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "methods"
+      ],
       "Hash": "4f2596dfb05dac67b9dc558e5c6fba2e"
     },
     "gridExtra": {
@@ -366,7 +549,13 @@
       "Version": "2.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "grDevices",
+        "graphics",
+        "grid",
+        "gtable",
+        "utils"
+      ],
       "Hash": "7d7f283939f563670a697165b2cf5560"
     },
     "gtable": {
@@ -374,7 +563,14 @@
       "Version": "0.3.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "cli",
+        "glue",
+        "grid",
+        "lifecycle",
+        "rlang"
+      ],
       "Hash": "b44addadb528a0d227794121c00572a0"
     },
     "highr": {
@@ -382,7 +578,10 @@
       "Version": "0.10",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "xfun"
+      ],
       "Hash": "06230136b2d2b9ba5805e1963fa6e890"
     },
     "hkdatasets": {
@@ -390,7 +589,11 @@
       "Version": "1.0.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "fst",
+        "utils"
+      ],
       "Hash": "37efab0a27c8e5ec5970912a0340ccab"
     },
     "htmltools": {
@@ -398,7 +601,16 @@
       "Version": "0.5.5",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "base64enc",
+        "digest",
+        "ellipsis",
+        "fastmap",
+        "grDevices",
+        "rlang",
+        "utils"
+      ],
       "Hash": "ba0240784ad50a62165058a27459304a"
     },
     "htmlwidgets": {
@@ -406,7 +618,14 @@
       "Version": "1.6.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "grDevices",
+        "htmltools",
+        "jsonlite",
+        "knitr",
+        "rmarkdown",
+        "yaml"
+      ],
       "Hash": "a865aa85bcb2697f47505bfd70422471"
     },
     "httpuv": {
@@ -414,7 +633,14 @@
       "Version": "1.6.11",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "R6",
+        "Rcpp",
+        "later",
+        "promises",
+        "utils"
+      ],
       "Hash": "838602f54e32c1a0f8cc80708cefcefa"
     },
     "httr": {
@@ -422,7 +648,14 @@
       "Version": "1.4.6",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "R6",
+        "curl",
+        "jsonlite",
+        "mime",
+        "openssl"
+      ],
       "Hash": "7e5e3cbd2a7bc07880c94e22348fb661"
     },
     "isoband": {
@@ -430,7 +663,10 @@
       "Version": "0.2.7",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "grid",
+        "utils"
+      ],
       "Hash": "0080607b4a1a7b28979aecef976d8bc2"
     },
     "jquerylib": {
@@ -438,7 +674,9 @@
       "Version": "0.1.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "htmltools"
+      ],
       "Hash": "5aab57a3bd297eee1c1d862735972182"
     },
     "jsonify": {
@@ -446,7 +684,11 @@
       "Version": "1.2.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "Rcpp",
+        "rapidjsonr"
+      ],
       "Hash": "49a9775e4f8c96c654b6018739067055"
     },
     "jsonlite": {
@@ -454,7 +696,9 @@
       "Version": "1.8.7",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "methods"
+      ],
       "Hash": "266a20443ca13c65688b2116d5220f76"
     },
     "knitr": {
@@ -462,7 +706,15 @@
       "Version": "1.43",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "evaluate",
+        "highr",
+        "methods",
+        "tools",
+        "xfun",
+        "yaml"
+      ],
       "Hash": "9775eb076713f627c07ce41d8199d8f6"
     },
     "labeling": {
@@ -470,7 +722,10 @@
       "Version": "0.4.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "graphics",
+        "stats"
+      ],
       "Hash": "3d5108641f47470611a32d0bdf357a72"
     },
     "later": {
@@ -478,7 +733,10 @@
       "Version": "1.3.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "Rcpp",
+        "rlang"
+      ],
       "Hash": "40401c9cf2bc2259dfe83311c9384710"
     },
     "lattice": {
@@ -486,7 +744,14 @@
       "Version": "0.20-45",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "grDevices",
+        "graphics",
+        "grid",
+        "stats",
+        "utils"
+      ],
       "Hash": "b64cdbb2b340437c4ee047a1f4c4377b"
     },
     "lazyeval": {
@@ -494,7 +759,9 @@
       "Version": "0.2.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R"
+      ],
       "Hash": "d908914ae53b04d4c0c0fd72ecc35370"
     },
     "leafem": {
@@ -502,7 +769,18 @@
       "Version": "0.2.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "base64enc",
+        "geojsonsf",
+        "htmltools",
+        "htmlwidgets",
+        "leaflet",
+        "methods",
+        "png",
+        "raster",
+        "sf"
+      ],
       "Hash": "db6e565a81ce81f137660467644e6fcd"
     },
     "leaflet": {
@@ -510,7 +788,24 @@
       "Version": "2.1.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "RColorBrewer",
+        "base64enc",
+        "crosstalk",
+        "htmltools",
+        "htmlwidgets",
+        "leaflet.providers",
+        "magrittr",
+        "markdown",
+        "methods",
+        "png",
+        "raster",
+        "scales",
+        "sp",
+        "stats",
+        "viridis"
+      ],
       "Hash": "ac2c7f21c2a6d2579eed8aaae4c42610"
     },
     "leaflet.extras": {
@@ -518,23 +813,39 @@
       "Version": "1.0.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "htmltools",
+        "htmlwidgets",
+        "leaflet",
+        "magrittr",
+        "stringr"
+      ],
       "Hash": "8dbfc2c4d7ca2660971caf1153ca95c2"
     },
     "leaflet.providers": {
       "Package": "leaflet.providers",
-      "Version": "1.9.0",
+      "Version": "2.0.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
-      "Hash": "d3082a7beac4a1aeb96100ff06265d7e"
+      "Requirements": [
+        "R",
+        "htmltools"
+      ],
+      "Hash": "c0b81ad9d5d932772f7a457ac398cf36"
     },
     "leafsync": {
       "Package": "leafsync",
       "Version": "0.1.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "htmltools",
+        "htmlwidgets",
+        "leaflet",
+        "methods"
+      ],
       "Hash": "819d7169c7d39f0f952473e943375da1"
     },
     "lifecycle": {
@@ -542,7 +853,12 @@
       "Version": "1.0.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "cli",
+        "glue",
+        "rlang"
+      ],
       "Hash": "001cecbeac1cff9301bdc3775ee46a86"
     },
     "lwgeom": {
@@ -550,7 +866,12 @@
       "Version": "0.2-13",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "Rcpp",
+        "sf",
+        "units"
+      ],
       "Hash": "9804362cc0267990ac61a85edeca73ed"
     },
     "magrittr": {
@@ -558,7 +879,9 @@
       "Version": "2.0.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R"
+      ],
       "Hash": "7ce2733a9826b3aeb1775d56fd305472"
     },
     "markdown": {
@@ -566,7 +889,12 @@
       "Version": "1.7",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "commonmark",
+        "utils",
+        "xfun"
+      ],
       "Hash": "0ffaea87c070a56d140ce00b0727b278"
     },
     "memoise": {
@@ -574,7 +902,10 @@
       "Version": "2.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "cachem",
+        "rlang"
+      ],
       "Hash": "e2817ccf4a065c5d9d7f2cfbe7c1d78c"
     },
     "mgcv": {
@@ -582,7 +913,16 @@
       "Version": "1.8-42",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "Matrix",
+        "R",
+        "graphics",
+        "methods",
+        "nlme",
+        "splines",
+        "stats",
+        "utils"
+      ],
       "Hash": "3460beba7ccc8946249ba35327ba902a"
     },
     "mime": {
@@ -590,7 +930,9 @@
       "Version": "0.12",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "tools"
+      ],
       "Hash": "18e9c28c1d3ca1560ce30658b22ce104"
     },
     "munsell": {
@@ -598,7 +940,10 @@
       "Version": "0.5.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "colorspace",
+        "methods"
+      ],
       "Hash": "6dfe8bf774944bd5595785e3229d8771"
     },
     "nlme": {
@@ -606,7 +951,13 @@
       "Version": "3.1-162",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "graphics",
+        "lattice",
+        "stats",
+        "utils"
+      ],
       "Hash": "0984ce8da8da9ead8643c5cbbb60f83e"
     },
     "openssl": {
@@ -614,7 +965,9 @@
       "Version": "2.0.6",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "askpass"
+      ],
       "Hash": "0f7cd2962e3044bb940cca4f4b5cecbe"
     },
     "packrat": {
@@ -622,7 +975,11 @@
       "Version": "0.9.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "tools",
+        "utils"
+      ],
       "Hash": "481428983c19a7c443f7ea1beff0a2de"
     },
     "pillar": {
@@ -630,7 +987,16 @@
       "Version": "1.9.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "cli",
+        "fansi",
+        "glue",
+        "lifecycle",
+        "rlang",
+        "utf8",
+        "utils",
+        "vctrs"
+      ],
       "Hash": "15da5a8412f317beeee6175fbc76f4bb"
     },
     "pkgconfig": {
@@ -638,7 +1004,9 @@
       "Version": "2.0.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "utils"
+      ],
       "Hash": "01f28d4278f15c76cddbea05899c5d6f"
     },
     "plotly": {
@@ -646,7 +1014,31 @@
       "Version": "4.10.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "RColorBrewer",
+        "base64enc",
+        "crosstalk",
+        "data.table",
+        "digest",
+        "dplyr",
+        "ggplot2",
+        "htmltools",
+        "htmlwidgets",
+        "httr",
+        "jsonlite",
+        "lazyeval",
+        "magrittr",
+        "promises",
+        "purrr",
+        "rlang",
+        "scales",
+        "tibble",
+        "tidyr",
+        "tools",
+        "vctrs",
+        "viridisLite"
+      ],
       "Hash": "6c00a09ba7d34917d9a3e28b15dd74e3"
     },
     "png": {
@@ -654,7 +1046,9 @@
       "Version": "0.1-8",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R"
+      ],
       "Hash": "bd54ba8a0a5faded999a7aab6e46b374"
     },
     "promises": {
@@ -662,7 +1056,14 @@
       "Version": "1.2.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R6",
+        "Rcpp",
+        "later",
+        "magrittr",
+        "rlang",
+        "stats"
+      ],
       "Hash": "4ab2c43adb4d4699cf3690acd378d75d"
     },
     "proxy": {
@@ -670,7 +1071,11 @@
       "Version": "0.4-27",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "stats",
+        "utils"
+      ],
       "Hash": "e0ef355c12942cf7a6b91a6cfaea8b3e"
     },
     "purrr": {
@@ -678,7 +1083,14 @@
       "Version": "1.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "cli",
+        "lifecycle",
+        "magrittr",
+        "rlang",
+        "vctrs"
+      ],
       "Hash": "d71c815267c640f17ddbf7f16144b4bb"
     },
     "rapidjsonr": {
@@ -686,15 +1098,16 @@
       "Version": "1.2.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "88b9f48c93d17cdb811b54079a6a414f",
-      "Requirements": []
+      "Hash": "88b9f48c93d17cdb811b54079a6a414f"
     },
     "rappdirs": {
       "Package": "rappdirs",
       "Version": "0.3.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R"
+      ],
       "Hash": "5e3c5dc0b071b21fa128676560dbe94d"
     },
     "raster": {
@@ -702,23 +1115,34 @@
       "Version": "3.6-23",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "Rcpp",
+        "methods",
+        "sp",
+        "terra"
+      ],
       "Hash": "337d6d70f7d6bf78df236a5a53f09db0"
     },
     "renv": {
       "Package": "renv",
       "Version": "1.0.0",
-      "OS_type": NA,
-      "Repository": "CRAN",
       "Source": "Repository",
-      "Requirements": []
+      "Repository": "CRAN",
+      "Requirements": [
+        "utils"
+      ],
+      "Hash": "c321cd99d56443dbffd1c9e673c0c1a2"
     },
     "rlang": {
       "Package": "rlang",
       "Version": "1.1.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "utils"
+      ],
       "Hash": "a85c767b55f0bf9b7ad16c6d7baee5bb"
     },
     "rmarkdown": {
@@ -726,7 +1150,23 @@
       "Version": "2.23",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "bslib",
+        "evaluate",
+        "fontawesome",
+        "htmltools",
+        "jquerylib",
+        "jsonlite",
+        "knitr",
+        "methods",
+        "stringr",
+        "tinytex",
+        "tools",
+        "utils",
+        "xfun",
+        "yaml"
+      ],
       "Hash": "79f14e53725f28900d936f692bfdd69f"
     },
     "rsconnect": {
@@ -734,7 +1174,17 @@
       "Version": "0.8.29",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "curl",
+        "digest",
+        "jsonlite",
+        "openssl",
+        "packrat",
+        "rstudioapi",
+        "tools",
+        "yaml"
+      ],
       "Hash": "fe178fc15af80952f546aafedf655b36"
     },
     "rstudioapi": {
@@ -742,15 +1192,18 @@
       "Version": "0.14",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "690bd2acc42a9166ce34845884459320",
-      "Requirements": []
+      "Hash": "690bd2acc42a9166ce34845884459320"
     },
     "s2": {
       "Package": "s2",
       "Version": "1.1.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "Rcpp",
+        "wk"
+      ],
       "Hash": "f1cbe03bb3346f8e817518ffa20f9f5a"
     },
     "sass": {
@@ -758,7 +1211,13 @@
       "Version": "0.4.6",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R6",
+        "fs",
+        "htmltools",
+        "rappdirs",
+        "rlang"
+      ],
       "Hash": "cc3ec7dd33982ef56570229b62d6388e"
     },
     "scales": {
@@ -766,7 +1225,17 @@
       "Version": "1.2.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "R6",
+        "RColorBrewer",
+        "farver",
+        "labeling",
+        "lifecycle",
+        "munsell",
+        "rlang",
+        "viridisLite"
+      ],
       "Hash": "906cb23d2f1c5680b8ce439b44c6fa63"
     },
     "sf": {
@@ -774,7 +1243,22 @@
       "Version": "1.0-13",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "DBI",
+        "R",
+        "Rcpp",
+        "classInt",
+        "grDevices",
+        "graphics",
+        "grid",
+        "magrittr",
+        "methods",
+        "s2",
+        "stats",
+        "tools",
+        "units",
+        "utils"
+      ],
       "Hash": "8fb4839843abc03528ff9f86424d6acd"
     },
     "sfheaders": {
@@ -782,7 +1266,11 @@
       "Version": "0.4.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "Rcpp",
+        "geometries"
+      ],
       "Hash": "0b0a55852e87b8f8478efb505eba2ebe"
     },
     "shiny": {
@@ -790,7 +1278,33 @@
       "Version": "1.7.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "R6",
+        "bslib",
+        "cachem",
+        "commonmark",
+        "crayon",
+        "ellipsis",
+        "fastmap",
+        "fontawesome",
+        "glue",
+        "grDevices",
+        "htmltools",
+        "httpuv",
+        "jsonlite",
+        "later",
+        "lifecycle",
+        "methods",
+        "mime",
+        "promises",
+        "rlang",
+        "sourcetools",
+        "tools",
+        "utils",
+        "withr",
+        "xtable"
+      ],
       "Hash": "c2eae3d8c670fa9dfa35a12066f4a1d5"
     },
     "shiny.i18n": {
@@ -798,7 +1312,18 @@
       "Version": "0.3.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "R6",
+        "glue",
+        "jsonlite",
+        "methods",
+        "rstudioapi",
+        "shiny",
+        "stringr",
+        "utils",
+        "yaml"
+      ],
       "Hash": "fb1b47e69750065a4f3c8c4ef24e4891"
     },
     "shinyWidgets": {
@@ -806,7 +1331,17 @@
       "Version": "0.7.6",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "anytime",
+        "bslib",
+        "grDevices",
+        "htmltools",
+        "jsonlite",
+        "rlang",
+        "sass",
+        "shiny"
+      ],
       "Hash": "fd889b32caa37b8ed9b1e9e7ef1564bc"
     },
     "shinydashboard": {
@@ -814,7 +1349,13 @@
       "Version": "0.7.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "htmltools",
+        "promises",
+        "shiny",
+        "utils"
+      ],
       "Hash": "e418b532e9bb4eb22a714b9a9f1acee7"
     },
     "shinyhelper": {
@@ -822,7 +1363,10 @@
       "Version": "0.3.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "markdown",
+        "shiny"
+      ],
       "Hash": "baef117734d5bd59373a561a15168679"
     },
     "sourcetools": {
@@ -830,7 +1374,9 @@
       "Version": "0.1.7-1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R"
+      ],
       "Hash": "5f5a7629f956619d519205ec475fe647"
     },
     "sp": {
@@ -838,7 +1384,16 @@
       "Version": "2.0-0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "grDevices",
+        "graphics",
+        "grid",
+        "lattice",
+        "methods",
+        "stats",
+        "utils"
+      ],
       "Hash": "2551981e6f85d59c81652bf654d6c3ca"
     },
     "stars": {
@@ -846,7 +1401,17 @@
       "Version": "0.6-1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "abind",
+        "classInt",
+        "lwgeom",
+        "methods",
+        "parallel",
+        "rlang",
+        "sf",
+        "units"
+      ],
       "Hash": "4dbde0da28637e13910e898960f2a993"
     },
     "stringi": {
@@ -854,7 +1419,12 @@
       "Version": "1.7.12",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "stats",
+        "tools",
+        "utils"
+      ],
       "Hash": "ca8bd84263c77310739d2cf64d84d7c9"
     },
     "stringr": {
@@ -862,7 +1432,16 @@
       "Version": "1.5.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "cli",
+        "glue",
+        "lifecycle",
+        "magrittr",
+        "rlang",
+        "stringi",
+        "vctrs"
+      ],
       "Hash": "671a4d384ae9d32fc47a14e98bfa3dc8"
     },
     "sys": {
@@ -870,15 +1449,18 @@
       "Version": "3.4.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "3a1be13d68d47a8cd0bfd74739ca1555",
-      "Requirements": []
+      "Hash": "3a1be13d68d47a8cd0bfd74739ca1555"
     },
     "terra": {
       "Package": "terra",
       "Version": "1.7-39",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "Rcpp",
+        "methods"
+      ],
       "Hash": "6037d18193ca3f16900646e773937094"
     },
     "tibble": {
@@ -886,7 +1468,18 @@
       "Version": "3.2.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "fansi",
+        "lifecycle",
+        "magrittr",
+        "methods",
+        "pillar",
+        "pkgconfig",
+        "rlang",
+        "utils",
+        "vctrs"
+      ],
       "Hash": "a84e2cc86d07289b3b6f5069df7a004c"
     },
     "tidyr": {
@@ -894,7 +1487,22 @@
       "Version": "1.3.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "cli",
+        "cpp11",
+        "dplyr",
+        "glue",
+        "lifecycle",
+        "magrittr",
+        "purrr",
+        "rlang",
+        "stringr",
+        "tibble",
+        "tidyselect",
+        "utils",
+        "vctrs"
+      ],
       "Hash": "e47debdc7ce599b070c8e78e8ac0cfcf"
     },
     "tidyselect": {
@@ -902,7 +1510,15 @@
       "Version": "1.2.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "cli",
+        "glue",
+        "lifecycle",
+        "rlang",
+        "vctrs",
+        "withr"
+      ],
       "Hash": "79540e5fcd9e0435af547d885f184fd5"
     },
     "tinytex": {
@@ -910,7 +1526,9 @@
       "Version": "0.45",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "xfun"
+      ],
       "Hash": "e4e357f28c2edff493936b6cb30c3d65"
     },
     "tmap": {
@@ -918,7 +1536,28 @@
       "Version": "3.3-3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "RColorBrewer",
+        "abind",
+        "classInt",
+        "grid",
+        "htmltools",
+        "htmlwidgets",
+        "leafem",
+        "leaflet",
+        "leafsync",
+        "methods",
+        "rlang",
+        "sf",
+        "stars",
+        "stats",
+        "tmaptools",
+        "units",
+        "utils",
+        "viridisLite",
+        "widgetframe"
+      ],
       "Hash": "7c1c0624e51105988b579d77289cea7b"
     },
     "tmaptools": {
@@ -926,7 +1565,21 @@
       "Version": "3.1-1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "RColorBrewer",
+        "XML",
+        "dichromat",
+        "grid",
+        "lwgeom",
+        "magrittr",
+        "methods",
+        "sf",
+        "stars",
+        "stats",
+        "units",
+        "viridisLite"
+      ],
       "Hash": "dfcb77371df343b663d6668d2d63ac35"
     },
     "units": {
@@ -934,7 +1587,10 @@
       "Version": "0.8-2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "Rcpp"
+      ],
       "Hash": "422376fe53419adcde4710d43acbcdd0"
     },
     "utf8": {
@@ -942,7 +1598,9 @@
       "Version": "1.2.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R"
+      ],
       "Hash": "1fe17157424bb09c48a8b3b550c753bc"
     },
     "vctrs": {
@@ -950,7 +1608,13 @@
       "Version": "0.6.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "cli",
+        "glue",
+        "lifecycle",
+        "rlang"
+      ],
       "Hash": "d0ef2856b83dc33ea6e255caf6229ee2"
     },
     "viridis": {
@@ -958,7 +1622,12 @@
       "Version": "0.6.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "ggplot2",
+        "gridExtra",
+        "viridisLite"
+      ],
       "Hash": "0d774f552202add033efc43a30293b3f"
     },
     "viridisLite": {
@@ -966,7 +1635,9 @@
       "Version": "0.4.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R"
+      ],
       "Hash": "c826c7c4241b6fc89ff55aaea3fa7491"
     },
     "widgetframe": {
@@ -974,7 +1645,15 @@
       "Version": "0.3.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "htmltools",
+        "htmlwidgets",
+        "magrittr",
+        "purrr",
+        "tools",
+        "utils"
+      ],
       "Hash": "0ee89e6cb58182d39b30a5b506e04808"
     },
     "withr": {
@@ -982,7 +1661,12 @@
       "Version": "2.5.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "grDevices",
+        "graphics",
+        "stats"
+      ],
       "Hash": "c0e49a9760983e81e55cdd9be92e7182"
     },
     "wk": {
@@ -990,7 +1674,9 @@
       "Version": "0.7.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R"
+      ],
       "Hash": "68a7ab6ec1afb5f076172b983c069313"
     },
     "xfun": {
@@ -998,7 +1684,10 @@
       "Version": "0.39",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "stats",
+        "tools"
+      ],
       "Hash": "8f56e9acb54fb525e66464d57ab58bcb"
     },
     "xtable": {
@@ -1006,7 +1695,11 @@
       "Version": "1.8-4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [],
+      "Requirements": [
+        "R",
+        "stats",
+        "utils"
+      ],
       "Hash": "b8acdf8af494d9ec19ccb2481a9b11c2"
     },
     "yaml": {
@@ -1014,8 +1707,7 @@
       "Version": "2.3.7",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "0d0056cc5383fbc240ccd0cb584bf436",
-      "Requirements": []
+      "Hash": "0d0056cc5383fbc240ccd0cb584bf436"
     }
   }
 }

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -3,6 +3,7 @@ local({
 
   # the requested version of renv
   version <- "1.0.0"
+  attr(version, "sha") <- NULL
 
   # the project directory
   project <- getwd()
@@ -60,21 +61,75 @@ local({
 
   # load bootstrap tools   
   `%||%` <- function(x, y) {
-    if (is.environment(x) || length(x)) x else y
+    if (is.null(x)) y else x
+  }
+  
+  catf <- function(fmt, ..., appendLF = TRUE) {
+  
+    quiet <- getOption("renv.bootstrap.quiet", default = FALSE)
+    if (quiet)
+      return(invisible())
+  
+    msg <- sprintf(fmt, ...)
+    cat(msg, file = stdout(), sep = if (appendLF) "\n" else "")
+  
+    invisible(msg)
+  
+  }
+  
+  header <- function(label,
+                     ...,
+                     prefix = "#",
+                     suffix = "-",
+                     n = min(getOption("width"), 78))
+  {
+    label <- sprintf(label, ...)
+    n <- max(n - nchar(label) - nchar(prefix) - 2L, 8L)
+    if (n <= 0)
+      return(paste(prefix, label))
+  
+    tail <- paste(rep.int(suffix, n), collapse = "")
+    paste0(prefix, " ", label, " ", tail)
+  
+  }
+  
+  startswith <- function(string, prefix) {
+    substring(string, 1, nchar(prefix)) == prefix
   }
   
   bootstrap <- function(version, library) {
   
+    friendly <- renv_bootstrap_version_friendly(version)
+    section <- header(sprintf("Bootstrapping renv %s", friendly))
+    catf(section)
+  
     # attempt to download renv
-    tarball <- tryCatch(renv_bootstrap_download(version), error = identity)
-    if (inherits(tarball, "error"))
-      stop("failed to download renv ", version)
+    catf("- Downloading renv ... ", appendLF = FALSE)
+    withCallingHandlers(
+      tarball <- renv_bootstrap_download(version),
+      error = function(err) {
+        catf("FAILED")
+        stop("failed to download:\n", conditionMessage(err))
+      }
+    )
+    catf("OK")
+    on.exit(unlink(tarball), add = TRUE)
   
     # now attempt to install
-    status <- tryCatch(renv_bootstrap_install(version, tarball, library), error = identity)
-    if (inherits(status, "error"))
-      stop("failed to install renv ", version)
+    catf("- Installing renv  ... ", appendLF = FALSE)
+    withCallingHandlers(
+      status <- renv_bootstrap_install(version, tarball, library),
+      error = function(err) {
+        catf("FAILED")
+        stop("failed to install:\n", conditionMessage(err))
+      }
+    )
+    catf("OK")
   
+    # add empty line to break up bootstrapping from normal output
+    catf("")
+  
+    return(invisible())
   }
   
   renv_bootstrap_tests_running <- function() {
@@ -83,28 +138,32 @@ local({
   
   renv_bootstrap_repos <- function() {
   
+    # get CRAN repository
+    cran <- getOption("renv.repos.cran", "https://cloud.r-project.org")
+  
     # check for repos override
     repos <- Sys.getenv("RENV_CONFIG_REPOS_OVERRIDE", unset = NA)
-    if (!is.na(repos))
+    if (!is.na(repos)) {
+  
+      # check for RSPM; if set, use a fallback repository for renv
+      rspm <- Sys.getenv("RSPM", unset = NA)
+      if (identical(rspm, repos))
+        repos <- c(RSPM = rspm, CRAN = cran)
+  
       return(repos)
+  
+    }
   
     # check for lockfile repositories
     repos <- tryCatch(renv_bootstrap_repos_lockfile(), error = identity)
     if (!inherits(repos, "error") && length(repos))
       return(repos)
   
-    # if we're testing, re-use the test repositories
-    if (renv_bootstrap_tests_running())
-      return(getOption("renv.tests.repos"))
-  
     # retrieve current repos
     repos <- getOption("repos")
   
     # ensure @CRAN@ entries are resolved
-    repos[repos == "@CRAN@"] <- getOption(
-      "renv.repos.cran",
-      "https://cloud.r-project.org"
-    )
+    repos[repos == "@CRAN@"] <- cran
   
     # add in renv.bootstrap.repos if set
     default <- c(FALLBACK = "https://cloud.r-project.org")
@@ -143,33 +202,34 @@ local({
   
   renv_bootstrap_download <- function(version) {
   
-    # if the renv version number has 4 components, assume it must
-    # be retrieved via github
-    nv <- numeric_version(version)
-    components <- unclass(nv)[[1]]
+    sha <- attr(version, "sha", exact = TRUE)
   
-    # if this appears to be a development version of 'renv', we'll
-    # try to restore from github
-    dev <- length(components) == 4L
+    methods <- if (!is.null(sha)) {
   
-    # begin collecting different methods for finding renv
-    methods <- c(
-      renv_bootstrap_download_tarball,
-      if (dev)
-        renv_bootstrap_download_github
-      else c(
-        renv_bootstrap_download_cran_latest,
-        renv_bootstrap_download_cran_archive
+      # attempting to bootstrap a development version of renv
+      c(
+        function() renv_bootstrap_download_tarball(sha),
+        function() renv_bootstrap_download_github(sha)
       )
-    )
+  
+    } else {
+  
+      # attempting to bootstrap a release version of renv
+      c(
+        function() renv_bootstrap_download_tarball(version),
+        function() renv_bootstrap_download_cran_latest(version),
+        function() renv_bootstrap_download_cran_archive(version)
+      )
+  
+    }
   
     for (method in methods) {
-      path <- tryCatch(method(version), error = identity)
+      path <- tryCatch(method(), error = identity)
       if (is.character(path) && file.exists(path))
         return(path)
     }
   
-    stop("failed to download renv ", version)
+    stop("All download methods failed")
   
   }
   
@@ -185,43 +245,75 @@ local({
     if (fixup)
       mode <- "w+b"
   
-    utils::download.file(
+    args <- list(
       url      = url,
       destfile = destfile,
       mode     = mode,
       quiet    = TRUE
     )
   
+    if ("headers" %in% names(formals(utils::download.file)))
+      args$headers <- renv_bootstrap_download_custom_headers(url)
+  
+    do.call(utils::download.file, args)
+  
+  }
+  
+  renv_bootstrap_download_custom_headers <- function(url) {
+  
+    headers <- getOption("renv.download.headers")
+    if (is.null(headers))
+      return(character())
+  
+    if (!is.function(headers))
+      stopf("'renv.download.headers' is not a function")
+  
+    headers <- headers(url)
+    if (length(headers) == 0L)
+      return(character())
+  
+    if (is.list(headers))
+      headers <- unlist(headers, recursive = FALSE, use.names = TRUE)
+  
+    ok <-
+      is.character(headers) &&
+      is.character(names(headers)) &&
+      all(nzchar(names(headers)))
+  
+    if (!ok)
+      stop("invocation of 'renv.download.headers' did not return a named character vector")
+  
+    headers
+  
   }
   
   renv_bootstrap_download_cran_latest <- function(version) {
   
     spec <- renv_bootstrap_download_cran_latest_find(version)
-  
-    message("* Downloading renv ", version, " ... ", appendLF = FALSE)
-  
     type  <- spec$type
     repos <- spec$repos
   
-    info <- tryCatch(
-      utils::download.packages(
-        pkgs    = "renv",
-        destdir = tempdir(),
-        repos   = repos,
-        type    = type,
-        quiet   = TRUE
-      ),
+    baseurl <- utils::contrib.url(repos = repos, type = type)
+    ext <- if (identical(type, "source"))
+      ".tar.gz"
+    else if (Sys.info()[["sysname"]] == "Windows")
+      ".zip"
+    else
+      ".tgz"
+    name <- sprintf("renv_%s%s", version, ext)
+    url <- paste(baseurl, name, sep = "/")
+  
+    destfile <- file.path(tempdir(), name)
+    status <- tryCatch(
+      renv_bootstrap_download_impl(url, destfile),
       condition = identity
     )
   
-    if (inherits(info, "condition")) {
-      message("FAILED")
+    if (inherits(status, "condition"))
       return(FALSE)
-    }
   
     # report success and return
-    message("OK (downloaded ", type, ")")
-    info[1, 2]
+    destfile
   
   }
   
@@ -277,8 +369,6 @@ local({
     urls <- file.path(repos, "src/contrib/Archive/renv", name)
     destfile <- file.path(tempdir(), name)
   
-    message("* Downloading renv ", version, " ... ", appendLF = FALSE)
-  
     for (url in urls) {
   
       status <- tryCatch(
@@ -286,14 +376,11 @@ local({
         condition = identity
       )
   
-      if (identical(status, 0L)) {
-        message("OK")
+      if (identical(status, 0L))
         return(destfile)
-      }
   
     }
   
-    message("FAILED")
     return(FALSE)
   
   }
@@ -307,8 +394,7 @@ local({
       return()
   
     # allow directories
-    info <- file.info(tarball, extra_cols = FALSE)
-    if (identical(info$isdir, TRUE)) {
+    if (dir.exists(tarball)) {
       name <- sprintf("renv_%s.tar.gz", version)
       tarball <- file.path(tarball, name)
     }
@@ -317,7 +403,7 @@ local({
     if (!file.exists(tarball)) {
   
       # let the user know we weren't able to honour their request
-      fmt <- "* RENV_BOOTSTRAP_TARBALL is set (%s) but does not exist."
+      fmt <- "- RENV_BOOTSTRAP_TARBALL is set (%s) but does not exist."
       msg <- sprintf(fmt, tarball)
       warning(msg)
   
@@ -326,10 +412,7 @@ local({
   
     }
   
-    fmt <- "* Bootstrapping with tarball at path '%s'."
-    msg <- sprintf(fmt, tarball)
-    message(msg)
-  
+    catf("- Using local tarball '%s'.", tarball)
     tarball
   
   }
@@ -356,8 +439,6 @@ local({
       on.exit(do.call(base::options, saved), add = TRUE)
     }
   
-    message("* Downloading renv ", version, " from GitHub ... ", appendLF = FALSE)
-  
     url <- file.path("https://api.github.com/repos/rstudio/renv/tarball", version)
     name <- sprintf("renv_%s.tar.gz", version)
     destfile <- file.path(tempdir(), name)
@@ -367,26 +448,105 @@ local({
       condition = identity
     )
   
-    if (!identical(status, 0L)) {
-      message("FAILED")
+    if (!identical(status, 0L))
       return(FALSE)
-    }
   
-    message("OK")
+    renv_bootstrap_download_augment(destfile)
+  
     return(destfile)
   
+  }
+  
+  # Add Sha to DESCRIPTION. This is stop gap until #890, after which we
+  # can use renv::install() to fully capture metadata.
+  renv_bootstrap_download_augment <- function(destfile) {
+    sha <- renv_bootstrap_git_extract_sha1_tar(destfile)
+    if (is.null(sha)) {
+      return()
+    }
+  
+    # Untar
+    tempdir <- tempfile("renv-github-")
+    on.exit(unlink(tempdir, recursive = TRUE), add = TRUE)
+    untar(destfile, exdir = tempdir)
+    pkgdir <- dir(tempdir, full.names = TRUE)[[1]]
+  
+    # Modify description
+    desc_path <- file.path(pkgdir, "DESCRIPTION")
+    desc_lines <- readLines(desc_path)
+    remotes_fields <- c(
+      "RemoteType: github",
+      "RemoteHost: api.github.com",
+      "RemoteRepo: renv",
+      "RemoteUsername: rstudio",
+      "RemotePkgRef: rstudio/renv",
+      paste("RemoteRef: ", sha),
+      paste("RemoteSha: ", sha)
+    )
+    writeLines(c(desc_lines[desc_lines != ""], remotes_fields), con = desc_path)
+  
+    # Re-tar
+    local({
+      old <- setwd(tempdir)
+      on.exit(setwd(old), add = TRUE)
+  
+      tar(destfile, compression = "gzip")
+    })
+    invisible()
+  }
+  
+  # Extract the commit hash from a git archive. Git archives include the SHA1
+  # hash as the comment field of the tarball pax extended header
+  # (see https://www.kernel.org/pub/software/scm/git/docs/git-archive.html)
+  # For GitHub archives this should be the first header after the default one
+  # (512 byte) header.
+  renv_bootstrap_git_extract_sha1_tar <- function(bundle) {
+  
+    # open the bundle for reading
+    # We use gzcon for everything because (from ?gzcon)
+    # > Reading from a connection which does not supply a ‘gzip’ magic
+    # > header is equivalent to reading from the original connection
+    conn <- gzcon(file(bundle, open = "rb", raw = TRUE))
+    on.exit(close(conn))
+  
+    # The default pax header is 512 bytes long and the first pax extended header
+    # with the comment should be 51 bytes long
+    # `52 comment=` (11 chars) + 40 byte SHA1 hash
+    len <- 0x200 + 0x33
+    res <- rawToChar(readBin(conn, "raw", n = len)[0x201:len])
+  
+    if (grepl("^52 comment=", res)) {
+      sub("52 comment=", "", res)
+    } else {
+      NULL
+    }
   }
   
   renv_bootstrap_install <- function(version, tarball, library) {
   
     # attempt to install it into project library
-    message("* Installing renv ", version, " ... ", appendLF = FALSE)
     dir.create(library, showWarnings = FALSE, recursive = TRUE)
+    output <- renv_bootstrap_install_impl(library, tarball)
+  
+    # check for successful install
+    status <- attr(output, "status")
+    if (is.null(status) || identical(status, 0L))
+      return(status)
+  
+    # an error occurred; report it
+    header <- "installation of renv failed"
+    lines <- paste(rep.int("=", nchar(header)), collapse = "")
+    text <- paste(c(header, lines, output), collapse = "\n")
+    stop(text)
+  
+  }
+  
+  renv_bootstrap_install_impl <- function(library, tarball) {
   
     # invoke using system2 so we can capture and report output
     bin <- R.home("bin")
     exe <- if (Sys.info()[["sysname"]] == "Windows") "R.exe" else "R"
-    r <- file.path(bin, exe)
+    R <- file.path(bin, exe)
   
     args <- c(
       "--vanilla", "CMD", "INSTALL", "--no-multiarch",
@@ -394,19 +554,7 @@ local({
       shQuote(path.expand(tarball))
     )
   
-    output <- system2(r, args, stdout = TRUE, stderr = TRUE)
-    message("Done!")
-  
-    # check for successful install
-    status <- attr(output, "status")
-    if (is.numeric(status) && !identical(status, 0L)) {
-      header <- "Error installing renv:"
-      lines <- paste(rep.int("=", nchar(header)), collapse = "")
-      text <- c(header, lines, output)
-      writeLines(text, con = stderr())
-    }
-  
-    status
+    system2(R, args, stdout = TRUE, stderr = TRUE)
   
   }
   
@@ -616,32 +764,58 @@ local({
   
   }
   
-  renv_bootstrap_validate_version <- function(version) {
+  renv_bootstrap_validate_version <- function(version, description = NULL) {
   
-    loadedversion <- utils::packageDescription("renv", fields = "Version")
-    if (version == loadedversion)
+    # resolve description file
+    description <- description %||% {
+      path <- getNamespaceInfo("renv", "path")
+      packageDescription("renv", lib.loc = dirname(path))
+    }
+  
+    # check whether requested version 'version' matches loaded version of renv
+    sha <- attr(version, "sha", exact = TRUE)
+    valid <- if (!is.null(sha))
+      renv_bootstrap_validate_version_dev(sha, description)
+    else
+      renv_bootstrap_validate_version_release(version, description)
+  
+    if (valid)
       return(TRUE)
   
-    # assume four-component versions are from GitHub; three-component
-    # versions are from CRAN
-    components <- strsplit(loadedversion, "[.-]")[[1]]
-    remote <- if (length(components) == 4L)
-      paste("rstudio/renv", loadedversion, sep = "@")
-    else
-      paste("renv", loadedversion, sep = "@")
+    # the loaded version of renv doesn't match the requested version;
+    # give the user instructions on how to proceed
+    remote <- if (!is.null(description[["RemoteSha"]])) {
+      paste("rstudio/renv", description[["RemoteSha"]], sep = "@")
+    } else {
+      paste("renv", description[["Version"]], sep = "@")
+    }
+  
+    # display both loaded version + sha if available
+    friendly <- renv_bootstrap_version_friendly(
+      version = description[["Version"]],
+      sha     = description[["RemoteSha"]]
+    )
   
     fmt <- paste(
       "renv %1$s was loaded from project library, but this project is configured to use renv %2$s.",
-      "Use `renv::record(\"%3$s\")` to record renv %1$s in the lockfile.",
-      "Use `renv::restore(packages = \"renv\")` to install renv %2$s into the project library.",
+      "- Use `renv::record(\"%3$s\")` to record renv %1$s in the lockfile.",
+      "- Use `renv::restore(packages = \"renv\")` to install renv %2$s into the project library.",
       sep = "\n"
     )
-  
-    msg <- sprintf(fmt, loadedversion, version, remote)
-    warning(msg, call. = FALSE)
+    catf(fmt, friendly, renv_bootstrap_version_friendly(version), remote)
   
     FALSE
   
+  }
+  
+  renv_bootstrap_validate_version_dev <- function(version, description) {
+    expected <- description[["RemoteSha"]]
+    is.character(expected) && startswith(expected, version)
+  }
+  
+  renv_bootstrap_validate_version_release <- function(version, description) {
+    expected <- description[["Version"]]
+    is.character(expected) && identical(expected, version)
   }
   
   renv_bootstrap_hash_text <- function(text) {
@@ -663,6 +837,12 @@ local({
     # warn if the version of renv loaded does not match
     renv_bootstrap_validate_version(version)
   
+    # execute renv load hooks, if any
+    hooks <- getHook("renv::autoload")
+    for (hook in hooks)
+      if (is.function(hook))
+        tryCatch(hook(), error = warning)
+  
     # load the project
     renv::load(project)
   
@@ -678,7 +858,7 @@ local({
       return(profile)
   
     # check for a profile file (nothing to do if it doesn't exist)
-    path <- renv_bootstrap_paths_renv("profile", profile = FALSE)
+    path <- renv_bootstrap_paths_renv("profile", profile = FALSE, project = project)
     if (!file.exists(path))
       return(NULL)
   
@@ -802,12 +982,78 @@ local({
   
   }
   
+  renv_bootstrap_version_friendly <- function(version, sha = NULL) {
+    sha <- sha %||% attr(version, "sha", exact = TRUE)
+    parts <- c(version, sprintf("[sha: %s]", substring(sha, 1L, 7L)))
+    paste(parts, collapse = " ")
+  }
+  
+  renv_bootstrap_run <- function(version, libpath) {
+  
+    # perform bootstrap
+    bootstrap(version, libpath)
+  
+    # exit early if we're just testing bootstrap
+    if (!is.na(Sys.getenv("RENV_BOOTSTRAP_INSTALL_ONLY", unset = NA)))
+      return(TRUE)
+  
+    # try again to load
+    if (requireNamespace("renv", lib.loc = libpath, quietly = TRUE)) {
+      return(renv::load(project = getwd()))
+    }
+  
+    # failed to download or load renv; warn the user
+    msg <- c(
+      "Failed to find an renv installation: the project will not be loaded.",
+      "Use `renv::activate()` to re-initialize the project."
+    )
+  
+    warning(paste(msg, collapse = "\n"), call. = FALSE)
+  
+  }
+  
+  
+  renv_bootstrap_in_rstudio <- function() {
+    commandArgs()[[1]] == "RStudio"
+  }
   
   renv_json_read <- function(file = NULL, text = NULL) {
   
+    jlerr <- NULL
+  
+    # if jsonlite is loaded, use that instead
+    if ("jsonlite" %in% loadedNamespaces()) {
+  
+      json <- catch(renv_json_read_jsonlite(file, text))
+      if (!inherits(json, "error"))
+        return(json)
+  
+      jlerr <- json
+  
+    }
+  
+    # otherwise, fall back to the default JSON reader
+    json <- catch(renv_json_read_default(file, text))
+    if (!inherits(json, "error"))
+      return(json)
+  
+    # report an error
+    if (!is.null(jlerr))
+      stop(jlerr)
+    else
+      stop(json)
+  
+  }
+  
+  renv_json_read_jsonlite <- function(file = NULL, text = NULL) {
     text <- paste(text %||% read(file), collapse = "\n")
+    jsonlite::fromJSON(txt = text, simplifyVector = FALSE)
+  }
+  
+  renv_json_read_default <- function(file = NULL, text = NULL) {
   
     # find strings in the JSON
+    text <- paste(text %||% read(file), collapse = "\n")
     pattern <- '["](?:(?:\\\\.)|(?:[^"\\\\]))*?["]'
     locs <- gregexpr(pattern, text, perl = TRUE)[[1]]
   
@@ -838,8 +1084,9 @@ local({
   
     # transform the JSON into something the R parser understands
     transformed <- replaced
-    transformed <- gsub("[[{]", "list(", transformed)
-    transformed <- gsub("[]}]", ")", transformed)
+    transformed <- gsub("{}", "`names<-`(list(), character())", transformed, fixed = TRUE)
+    transformed <- gsub("[[{]", "list(", transformed, perl = TRUE)
+    transformed <- gsub("[]}]", ")", transformed, perl = TRUE)
     transformed <- gsub(":", "=", transformed, fixed = TRUE)
     text <- paste(transformed, collapse = "\n")
   
@@ -912,31 +1159,23 @@ local({
   if (renv_bootstrap_load(project, libpath, version))
     return(TRUE)
 
-  # load failed; inform user we're about to bootstrap
-  prefix <- paste("# Bootstrapping renv", version)
-  postfix <- paste(rep.int("-", 77L - nchar(prefix)), collapse = "")
-  header <- paste(prefix, postfix)
-  message(header)
+  if (renv_bootstrap_in_rstudio()) {
+    setHook("rstudio.sessionInit", function(...) {
+      renv_bootstrap_run(version, libpath)
 
-  # perform bootstrap
-  bootstrap(version, libpath)
-
-  # exit early if we're just testing bootstrap
-  if (!is.na(Sys.getenv("RENV_BOOTSTRAP_INSTALL_ONLY", unset = NA)))
-    return(TRUE)
-
-  # try again to load
-  if (requireNamespace("renv", lib.loc = libpath, quietly = TRUE)) {
-    message("* Successfully installed and loaded renv ", version, ".")
-    return(renv::load())
+      # Work around buglet in RStudio if hook uses readline
+      tryCatch(
+        {
+          tools <- as.environment("tools:rstudio")
+          tools$.rs.api.sendToConsole("", echo = FALSE, focus = FALSE)
+        },
+        error = function(cnd) {}
+      )
+    })
+  } else {
+    renv_bootstrap_run(version, libpath)
   }
 
-  # failed to download or load renv; warn the user
-  msg <- c(
-    "Failed to find an renv installation: the project will not be loaded.",
-    "Use `renv::activate()` to re-initialize the project."
-  )
-
-  warning(paste(msg, collapse = "\n"), call. = FALSE)
+  invisible()
 
 })


### PR DESCRIPTION
# Summary

This branch changes all basemap back to Stamen Tonerlite style after the basemap data is updated with [Stamen Toner map tile migrated to Stadia](https://docs.stadiamaps.com/guides/migrating-from-stamen-map-tiles/).

Closes #54 and closes #107 

# Changes

The changes made in this PR are:

1. Upgrade {leaflet.providers} to v2.
2. Use the new provider name for Tonerlite basemap.
3. Use Tonerlite as the default basemap. 

***

# Check

- [x] (If UI & data are updated) The UI & data includes Traditional Chinese translation, with translation terms wrapped in `i18n$t()` and terms added to `translation_zh.csv`
- [x] The GitHub Actions workflows pass.

***

## Note

The history of change of the basemap provider service link is available at https://stamen.com/here-comes-the-future-of-stamen-maps/.
