### PR TITLE
fix: Set shiny deployment server time locale to Hong Kong time

### DIFF
--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -34,6 +34,11 @@ library(tmap)
 library(DT, warn.conflicts = FALSE)
 
 
+# System settings -------------------------------------------------------------
+
+Sys.setenv(TZ = "Asia/Hong_Kong")
+
+
 # Metadata -------------------------------------------------------------
 
 # opengraph properties


### PR DESCRIPTION
# Summary

This branch sets the timezone of the R locale in the Shinyapps server to Hong Kong time (GMT+8) (fixes #88).

***

# Check

- [x] (If UI & data are updated) The UI & data includes Traditional Chinese translation, with translation terms wrapped in `i18n$t()` and terms added to `translation_zh.csv`
- [x] The GitHub Actions workflows pass.
