### PR TITLE
Feat: Restricting the height of the collision map and filter panel

### DIFF
--- a/inst/app/www/styles.css
+++ b/inst/app/www/styles.css
@@ -19,6 +19,7 @@
     top and bottom heading inside box is 10px each */
     height: calc(100vh - 200px);
     overflow: auto;
+    margin-top: 20px;
   }
 
   #main_map {

--- a/inst/app/www/styles.css
+++ b/inst/app/www/styles.css
@@ -13,6 +13,21 @@
   max-height: calc(100vh - 150px);
 }
 
+@media (max-width:768px) {
+  #controls {
+    /* Header is 50px, top and bottom padding of content panel is 15px each, bottom margin of the box is 20px,
+    top and bottom heading inside box is 10px each */
+    height: calc(100vh - 200px);
+    overflow: auto;
+  }
+
+  #main_map {
+    max-height: calc(100vh - 200px);
+  }
+}
+
+
+
 /* dashboard body, excluding sidebar */
 .content-wrapper, .right-side {
   background-color: #eeeeee;

--- a/inst/app/www/styles.css
+++ b/inst/app/www/styles.css
@@ -1,6 +1,16 @@
 #controls {
-  height: 100vh;
+  /* Height of elements in shinydashboard:
+    - Header: 50px,
+    - Top and bottom padding of content panel: 15px each
+    - Bottom margin of box in fluidRow: 20px
+    - Top and bottom padding of box in fluidRow: 10px each
+    */
+  height: calc(100vh - 150px);
   overflow: auto;
+}
+
+#main_map {
+  max-height: calc(100vh - 150px);
 }
 
 /* dashboard body, excluding sidebar */


### PR DESCRIPTION
# Summary

This branch refines the UI of the collision map tab by restricting the height of the collision map and filter panel.

# Changes

The changes made in this PR are:

1. Set the maximum height of the collision map and filter panel. This prevents these elements from having a bigger height than the user's viewport's height.
2. Add a margin between the collision map and filter panel in a narrow screen width. 

## Before

![before](https://github.com/Hong-Kong-Districts-Info/hktrafficcollisions/assets/29334677/29a7ceee-c07b-41b6-b349-4e67acf10de3)

## After

![after](https://github.com/Hong-Kong-Districts-Info/hktrafficcollisions/assets/29334677/a956790a-59aa-470d-aabb-bcf18334a13e)


***

# Check

- [ ] (If UI & data are updated) The UI & data includes Traditional Chinese translation, with translation terms wrapped in `i18n$t()` and terms added to `translation_zh.csv`
- [ ] The GitHub Actions workflows pass.

***

## Note

Shinydashboard will collapse the sidebar and make fluidRow stacks when the screen width is smaller than 768px. Here narrow viewport refers to screen width smaller than 768px.

There seems to be a better way to set the height of the box containing the collision map and filter panel directly. Could consider refactoring afterwards.
