### PR TITLE
Feat: Add "All Districts" category in District Dashboard

### DIFF
--- a/inst/app/modules/district_dsb.R
+++ b/inst/app/modules/district_dsb.R
@@ -75,10 +75,10 @@ output$dsb_filter_ui = renderUI({
   selectInput(
     inputId = "ddsb_district_filter", label = i18n$t("District"),
     choices = stats::setNames(
-      DISTRICT_ABBR,
-      lapply(DISTRICT_FULL_NAME, function(x) i18n$t(x))
+      c("All Districts", DISTRICT_ABBR),
+      lapply(c("All Districts", DISTRICT_FULL_NAME), function(x) i18n$t(x))
     ),
-    selected = "CW"
+    selected = "All Districts"
   )
 })
 
@@ -96,13 +96,18 @@ output$ksi_filter_ui = renderUI({
 
 # Return filtered hk_collisions dataframe according to users' selected inputs
 ddsb_filtered_hk_collisions = reactive({
-  # filter by users' selected district
-  # FIXME: Temp workaround to fix non-initialised value when district filter renders in server side
-  ddsb_district_filter = if (is.null(input$ddsb_district_filter)) "CW" else input$ddsb_district_filter
-  hk_collisions_filtered = filter(hk_collisions, district == ddsb_district_filter)
+
+  # Avoid non-initialised value when district filter renders in server side
+  validate(
+    need(!is.null(input$ddsb_district_filter), "Please select a district"),
+  )
 
   # filter by users' selected time range
-  hk_collisions_filtered = filter(hk_collisions_filtered, year >= input$ddsb_year_filter[1] & year <= input$ddsb_year_filter[2])
+  hk_collisions_filtered = filter(hk_collisions, year >= input$ddsb_year_filter[1] & year <= input$ddsb_year_filter[2])
+
+  if (input$ddsb_district_filter != "All Districts") {
+    hk_collisions_filtered = filter(hk_collisions_filtered, district == input$ddsb_district_filter)
+  }
 
   # remove slightly injured collisions if user select "KSI only" option
   # FIXME: Temp workaround to fix non-initialised value when KSI filter renders in server side

--- a/inst/app/modules/district_dsb_all.R
+++ b/inst/app/modules/district_dsb_all.R
@@ -20,6 +20,13 @@ ddsb_filtered_hk_vehicles = reactive({
 })
 
 all_grid_count = reactive({
+  # Do not generate collision location map when "All Districts" is selected
+  validate(
+    need(input$ddsb_district_filter != "All Districts",
+         "要查看車禍位置地圖，請於上面地區選項中選擇「全港」以外的地區。\nTo view the collision location map, please select districts other than \"All Districts\" in the district filter above"
+    )
+  )
+
   count_collisions_in_grid(ddsb_filtered_hk_collisions())
 })
 

--- a/inst/app/modules/district_dsb_cyc.R
+++ b/inst/app/modules/district_dsb_cyc.R
@@ -43,6 +43,13 @@ ddsb_cyc_filtered_hk_vehicles_wo_cycle = reactive({
 
 
 cyc_grid_count = reactive({
+  # Do not generate collision location map when "All Districts" is selected
+  validate(
+    need(input$ddsb_district_filter != "All Districts",
+         "要查看車禍位置地圖，請於上面地區選項中選擇「全港」以外的地區。\nTo view the collision location map, please select districts other than \"All Districts\" in the district filter above"
+    )
+  )
+
   count_collisions_in_grid(ddsb_cyc_filtered_hk_collisions())
 })
 

--- a/inst/app/modules/district_dsb_ped.R
+++ b/inst/app/modules/district_dsb_ped.R
@@ -23,6 +23,13 @@ ddsb_ped_filtered_hk_vehicles = reactive({
 })
 
 ped_grid_count = reactive({
+  # Do not generate collision location map when "All Districts" is selected
+  validate(
+    need(input$ddsb_district_filter != "All Districts",
+         "要查看車禍位置地圖，請於上面地區選項中選擇「全港」以外的地區。\nTo view the collision location map, please select districts other than \"All Districts\" in the district filter above"
+         )
+  )
+
   count_collisions_in_grid(ddsb_ped_filtered_hk_collisions())
 })
 

--- a/inst/app/translation/translation_zh.csv
+++ b/inst/app/translation/translation_zh.csv
@@ -35,6 +35,7 @@ Sai Kung,西貢區
 Sha Tin,沙田區
 Kwai Tsing,葵青區
 Islands,離島區
+All Districts,全港
 Fatal,致命
 Serious,嚴重
 Slight,輕微


### PR DESCRIPTION
# Summary

This branch adds the "All Districts" category in the District Dashboard to show summary of Hong Kong overall (i.e. all 18 Districts in HK).

# Changes

The changes made in this PR are:

1. Add "All Districts" category (全港) in the district filter of the District Dashboard to allow users to view related summary figures of the whole territory.
2. Do not generate collision location map when "All Districts" is selected and show guidance message. Generating the grid map is currently computationally intensive.

![all-districts-preview](https://github.com/user-attachments/assets/6047fdba-0e0c-46e3-b777-8533180a8ac7)


***

# Check

- [x] (If UI & data are updated) The UI & data includes Traditional Chinese translation, with translation terms wrapped in `i18n$t()` and terms added to `translation_zh.csv`
- [x] The GitHub Actions workflows pass.

