### PR TITLE
Refactor: Better handing of missing outputs

### DIFF
--- a/inst/app/modules/district_dsb.R
+++ b/inst/app/modules/district_dsb.R
@@ -97,14 +97,17 @@ output$ksi_filter_ui = renderUI({
 # Return filtered hk_collisions dataframe according to users' selected inputs
 ddsb_filtered_hk_collisions = reactive({
 
-  # Avoid non-initialised value when district filter renders in server side
   # Ensure KSI filter values are initialised before filtering data
   req(
     input$ddsb_ksi_filter
   )
 
+  # Avoid displaying red errors messages when filter values are not set correctly
+  # https://shiny.posit.co/r/articles/improve/validation/
   validate(
     need(!is.null(input$ddsb_district_filter), "Please select a district"),
+    need(!is.null(input$ddsb_year_filter), "Please select a year period"),
+    need(!is.null(input$ddsb_ksi_filter), "Please select a KSI category")
   )
 
   # filter by users' selected time range

--- a/inst/app/modules/district_dsb.R
+++ b/inst/app/modules/district_dsb.R
@@ -75,10 +75,10 @@ output$dsb_filter_ui = renderUI({
   selectInput(
     inputId = "ddsb_district_filter", label = i18n$t("District"),
     choices = stats::setNames(
-      DISTRICT_ABBR,
-      lapply(DISTRICT_FULL_NAME, function(x) i18n$t(x))
+      c("All Districts", DISTRICT_ABBR),
+      lapply(c("All Districts", DISTRICT_FULL_NAME), function(x) i18n$t(x))
     ),
-    selected = "CW"
+    selected = "All Districts"
   )
 })
 
@@ -96,13 +96,18 @@ output$ksi_filter_ui = renderUI({
 
 # Return filtered hk_collisions dataframe according to users' selected inputs
 ddsb_filtered_hk_collisions = reactive({
-  # filter by users' selected district
-  # FIXME: Temp workaround to fix non-initialised value when district filter renders in server side
-  ddsb_district_filter = if (is.null(input$ddsb_district_filter)) "CW" else input$ddsb_district_filter
-  hk_collisions_filtered = filter(hk_collisions, district == ddsb_district_filter)
+
+  # Avoid non-initialised value when district filter renders in server side
+  validate(
+    need(!is.null(input$ddsb_district_filter), "Please select a district"),
+  )
 
   # filter by users' selected time range
-  hk_collisions_filtered = filter(hk_collisions_filtered, year >= input$ddsb_year_filter[1] & year <= input$ddsb_year_filter[2])
+  hk_collisions_filtered = filter(hk_collisions, year >= input$ddsb_year_filter[1] & year <= input$ddsb_year_filter[2])
+
+  if (input$ddsb_district_filter != "All Districts") {
+    hk_collisions_filtered = filter(hk_collisions_filtered, district == input$ddsb_district_filter)
+  }
 
   # remove slightly injured collisions if user select "KSI only" option
   # FIXME: Temp workaround to fix non-initialised value when KSI filter renders in server side

--- a/inst/app/modules/district_dsb.R
+++ b/inst/app/modules/district_dsb.R
@@ -98,6 +98,11 @@ output$ksi_filter_ui = renderUI({
 ddsb_filtered_hk_collisions = reactive({
 
   # Avoid non-initialised value when district filter renders in server side
+  # Ensure KSI filter values are initialised before filtering data
+  req(
+    input$ddsb_ksi_filter
+  )
+
   validate(
     need(!is.null(input$ddsb_district_filter), "Please select a district"),
   )
@@ -110,10 +115,7 @@ ddsb_filtered_hk_collisions = reactive({
   }
 
   # remove slightly injured collisions if user select "KSI only" option
-  # FIXME: Temp workaround to fix non-initialised value when KSI filter renders in server side
-  ddsb_ksi_filter = if (is.null(input$ddsb_ksi_filter)) "all" else input$ddsb_ksi_filter
-
-  if (ddsb_ksi_filter == "ksi_only") {
+  if (input$ddsb_ksi_filter == "ksi_only") {
     hk_collisions_filtered = filter(hk_collisions_filtered, severity != "Slight")
   }
 

--- a/inst/app/modules/district_dsb_all.R
+++ b/inst/app/modules/district_dsb_all.R
@@ -20,6 +20,13 @@ ddsb_filtered_hk_vehicles = reactive({
 })
 
 all_grid_count = reactive({
+  # Do not generate collision location map when "All Districts" is selected
+  validate(
+    need(input$ddsb_district_filter != "All Districts",
+         "要查看車禍位置地圖，請於上面地區選項中選擇「全港」以外的地區。\nTo view the collision location map, please select districts other than \"All Districts\" in the district filter above"
+    )
+  )
+
   count_collisions_in_grid(ddsb_filtered_hk_collisions())
 })
 

--- a/inst/app/modules/district_dsb_all.R
+++ b/inst/app/modules/district_dsb_all.R
@@ -63,7 +63,7 @@ output$box_all_serious_stat = renderInfoBox({
 
   infoBox(
     title = "",
-    value = paste0(n_serious, " (", serious_per, "%)"),
+    value = paste0(format(n_serious, big.mark=","), " (", serious_per, "%)"),
     subtitle = i18n$t("Serious casualties (% of total)"),
     icon = icon("procedures"),
     color = "orange"
@@ -77,7 +77,7 @@ output$box_all_fatal_stat = renderInfoBox({
   infoBox(
     title = "",
     subtitle = i18n$t("Fatal casualties (% of total)"),
-    value = paste0(n_fatal, " (", fatal_per, "%)"),
+    value = paste0(format(n_fatal, big.mark=","), " (", fatal_per, "%)"),
     icon = icon("skull-crossbones"),
     color = "red"
   )

--- a/inst/app/modules/district_dsb_cyc.R
+++ b/inst/app/modules/district_dsb_cyc.R
@@ -85,7 +85,7 @@ output$box_cyc_serious_stat = renderInfoBox({
 
   infoBox(
     title = "",
-    value = paste0(n_serious, " (", serious_per, "%)"),
+    value = paste0(format(n_serious, big.mark=","), " (", serious_per, "%)"),
     subtitle = i18n$t("Serious casualties (% of total)"),
     icon = icon("procedures"),
     color = "orange"
@@ -99,7 +99,7 @@ output$box_cyc_fatal_stat = renderInfoBox({
   infoBox(
     title = "",
     subtitle = i18n$t("Fatal casualties (% of total)"),
-    value = paste0(n_fatal, " (", fatal_per, "%)"),
+    value = paste0(format(n_fatal, big.mark=","), " (", fatal_per, "%)"),
     icon = icon("skull-crossbones"),
     color = "red"
   )

--- a/inst/app/modules/district_dsb_cyc.R
+++ b/inst/app/modules/district_dsb_cyc.R
@@ -43,6 +43,13 @@ ddsb_cyc_filtered_hk_vehicles_wo_cycle = reactive({
 
 
 cyc_grid_count = reactive({
+  # Do not generate collision location map when "All Districts" is selected
+  validate(
+    need(input$ddsb_district_filter != "All Districts",
+         "要查看車禍位置地圖，請於上面地區選項中選擇「全港」以外的地區。\nTo view the collision location map, please select districts other than \"All Districts\" in the district filter above"
+    )
+  )
+
   count_collisions_in_grid(ddsb_cyc_filtered_hk_collisions())
 })
 

--- a/inst/app/modules/district_dsb_ped.R
+++ b/inst/app/modules/district_dsb_ped.R
@@ -66,7 +66,7 @@ output$box_ped_serious_stat = renderInfoBox({
 
   infoBox(
     title = "",
-    value = paste0(n_serious, " (", serious_per, "%)"),
+    value = paste0(format(n_serious, big.mark=","), " (", serious_per, "%)"),
     subtitle = i18n$t("Serious casualties (% of total)"),
     icon = icon("procedures"),
     color = "orange"
@@ -80,7 +80,7 @@ output$box_ped_fatal_stat = renderInfoBox({
   infoBox(
     title = "",
     subtitle = i18n$t("Fatal casualties (% of total)"),
-    value = paste0(n_fatal, " (", fatal_per, "%)"),
+    value = paste0(format(n_fatal, big.mark=","), " (", fatal_per, "%)"),
     icon = icon("skull-crossbones"),
     color = "red"
   )

--- a/inst/app/modules/district_dsb_ped.R
+++ b/inst/app/modules/district_dsb_ped.R
@@ -23,6 +23,13 @@ ddsb_ped_filtered_hk_vehicles = reactive({
 })
 
 ped_grid_count = reactive({
+  # Do not generate collision location map when "All Districts" is selected
+  validate(
+    need(input$ddsb_district_filter != "All Districts",
+         "要查看車禍位置地圖，請於上面地區選項中選擇「全港」以外的地區。\nTo view the collision location map, please select districts other than \"All Districts\" in the district filter above"
+         )
+  )
+
   count_collisions_in_grid(ddsb_ped_filtered_hk_collisions())
 })
 

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -159,18 +159,13 @@ filter_collision_data <-
     millis = 750,
     r = reactive({
 
-      # Test for checking initialise value of date, will return TRUE when render airDatepickerInput in server side
-      # message("is.null(input$end_month): ", is.null(input$end_month))
+      # Ensure month filter values are initialised when airDatepickerInput renders in server side
+      req(
+        input$month_range
+      )
 
-      # HACK: Temp workaround to fix non-initialised month value when airDatepickerInput renders in server side
-      if (is.null(input$month_range)) {
-        data_filtered = filter(hk_collisions_valid_sf,
-                               year_month >= floor_date_to_month(as.Date("2021-01-01")) & year_month <= floor_date_to_month(as.Date("2021-12-01")))
-      } else {
-        data_filtered = filter(hk_collisions_valid_sf,
-                               year_month >= floor_date_to_month(input$month_range[1]) & year_month <= floor_date_to_month(input$month_range[2]))
-      }
-
+      data_filtered = filter(hk_collisions_valid_sf,
+                             year_month >= floor_date_to_month(input$month_range[1]) & year_month <= floor_date_to_month(input$month_range[2]))
 
       message("Min date in filtered data: ", min(data_filtered$date_time))
       message("Max date in filtered data: ", max(data_filtered$date_time))

--- a/inst/app/translation/translation_zh.csv
+++ b/inst/app/translation/translation_zh.csv
@@ -35,6 +35,7 @@ Sai Kung,西貢區
 Sha Tin,沙田區
 Kwai Tsing,葵青區
 Islands,離島區
+All Districts,全港
 Fatal,致命
 Serious,嚴重
 Slight,輕微


### PR DESCRIPTION
# Changes

The changes made in this PR are:

1. Use `req()` to ensure several filter values are initialised / non-missing before running reactives to filter the data
2. Use `validate()` to indicate which filter values are not correctly selected in the District Dashboard 
3. Add thousand separator for total casualties numbers

***

# Check

- [x] (If UI & data are updated) The UI & data includes Traditional Chinese translation, with translation terms wrapped in `i18n$t()` and terms added to `translation_zh.csv`
- [x] The GitHub Actions workflows pass.

***

# Note

- https://shiny.posit.co/r/articles/improve/req/
- https://shiny.posit.co/r/articles/improve/validation/