### PR TITLE
Chore: Fix breaking changes in {tmap} v4

### DIFF
--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -81,7 +81,7 @@ hotzone_out_df = fst::read_fst("./data/data-manipulated/hotzone_out_df.fst")
 SELECTED_BASEMAPS = c("Stadia.StamenTonerLite", "OpenStreetMap", "CartoDB.Positron")
 
 tmap_mode("view")
-tmap_options(basemaps = SELECTED_BASEMAPS)
+tmap_options(basemap.server = SELECTED_BASEMAPS)
 
 # Constants ---------------------------------------------------------------
 

--- a/inst/app/modules/district_dsb_all.R
+++ b/inst/app/modules/district_dsb_all.R
@@ -87,20 +87,15 @@ output$box_all_fatal_stat = renderInfoBox({
 output$ddsb_all_collision_heatmap = renderTmap({
 
   tm_shape(all_grid_count()) +
-    tm_fill(
+    tm_polygons(
+      fill = "n_colli",
+      fill.scale = tm_scale(values = "matplotlib.purples"),
+      fill_alpha = 0.8,
+      fill.legend = tm_legend(title = i18n$t("Number of collisions")),
+
       group = i18n$t("Number of collisions"),
-      col = "n_colli",
-      palette = "Purples",
-      n = 10,
-      style = "cont",
-      title = i18n$t("Number of collisions"),
-      id = "n_colli",
-      showNA = FALSE,
-      alpha = 0.8,
-      # disable popups
-      popup.vars = FALSE,
-    ) +
-    tm_borders(col = "#232323", lwd = 0.7)
+      popup.vars = c("Number of collisions" = "n_colli")
+    )
 
 })
 

--- a/inst/app/modules/district_dsb_cyc.R
+++ b/inst/app/modules/district_dsb_cyc.R
@@ -110,20 +110,15 @@ output$box_cyc_fatal_stat = renderInfoBox({
 output$ddsb_cyc_collision_heatmap = renderTmap({
 
   tm_shape(cyc_grid_count()) +
-    tm_fill(
+    tm_polygons(
+      fill = "n_colli",
+      fill.scale = tm_scale(values = "matplotlib.purples"),
+      fill_alpha = 0.8,
+      fill.legend = tm_legend(title = i18n$t("Number of collisions")),
+
       group = i18n$t("Number of collisions"),
-      col = "n_colli",
-      palette = "Purples",
-      n = 10,
-      style = "cont",
-      title = i18n$t("Number of collisions"),
-      id = "n_colli",
-      showNA = FALSE,
-      alpha = 0.8,
-      # disable popups
-      popup.vars = FALSE,
-    ) +
-    tm_borders(col = "#232323", lwd = 0.7)
+      popup.vars = c("Number of collisions" = "n_colli")
+    )
 
 })
 

--- a/inst/app/modules/district_dsb_ped.R
+++ b/inst/app/modules/district_dsb_ped.R
@@ -92,21 +92,15 @@ output$box_ped_fatal_stat = renderInfoBox({
 output$ddsb_ped_collision_heatmap = renderTmap({
 
   tm_shape(ped_grid_count()) +
-    tm_fill(
-      group = i18n$t("Number of collisions"),
-      col = "n_colli",
-      palette = "Purples",
-      n = 10,
-      style = "cont",
-      title = i18n$t("Number of collisions"),
-      id = "n_colli",
-      showNA = FALSE,
-      alpha = 0.8,
-      # disable popups
-      popup.vars = FALSE,
-    ) +
-    tm_borders(col = "#232323", lwd = 0.7)
+    tm_polygons(
+      fill = "n_colli",
+      fill.scale = tm_scale(values = "matplotlib.purples"),
+      fill_alpha = 0.8,
+      fill.legend = tm_legend(title = i18n$t("Number of collisions")),
 
+      group = i18n$t("Number of collisions"),
+      popup.vars = c("Number of collisions" = "n_colli")
+    )
 })
 
 # Collision number by severity

--- a/inst/app/modules/hotzones.R
+++ b/inst/app/modules/hotzones.R
@@ -49,16 +49,23 @@ output$hotzones_map = renderTmap({
   tm_shape(hotzone_streets) +
     tm_lines(
       group = i18n$t("Hotzone streets"),
-      title.col = i18n$t("Hotzone Rank"),
       id = if(input$selected_language == "en") {"Name"} else {"Name_zh"},
       col = "Area_RK",
       lwd = 7.5,
-      palette = "inferno",
-      # Use only first half of inferno palette as the light color part does not show well on grey basemap
-      contrast = c(0, .5),
-      n = max(hotzone_streets[["Area_RK"]]),
-      style = "cont",
-      alpha = 1,
+
+      col.scale = tm_scale_continuous(
+        n = max(hotzone_streets[["Area_RK"]]),
+        values = "inferno",
+        # Use only first half of inferno palette as the light color part does not show well on grey basemap
+        values.range = c(0, .5)
+      ),
+      col_alpha = 1,
+      col.legend = tm_legend(
+        title = i18n$t("Hotzone Rank"),
+        orientation = "landscape",
+        width = 20
+      ),
+
       popup.vars = if(input$selected_language == "en") {POPUP_COLUMN_NAMES_EN} else {POP_COLUMN_NAMES_ZH}
     )
 })

--- a/inst/app/modules/hotzones.R
+++ b/inst/app/modules/hotzones.R
@@ -60,9 +60,7 @@ output$hotzones_map = renderTmap({
       style = "cont",
       alpha = 1,
       popup.vars = if(input$selected_language == "en") {POPUP_COLUMN_NAMES_EN} else {POP_COLUMN_NAMES_ZH}
-    ) +
-    tm_tiles(COLLISION_PTS_TILE_URL, group = i18n$t("Collisions with pedestrian injuries"))
-
+    )
 })
 
 observe({

--- a/inst/app/modules/hotzones.R
+++ b/inst/app/modules/hotzones.R
@@ -2,7 +2,7 @@
 # Add tile from mapbox style
 # https://docs.mapbox.com/studio-manual/guides/publish-your-style/
 COLLISION_PTS_TILE_URL = paste0(
-  "https://api.mapbox.com/styles/v1/khwong12/ckz18sv3a004415qrmcs9geal/tiles/256/{z}/{x}/{y}?access_token=",
+  "https://api.mapbox.com/styles/v1/khwong12/ckyxixwuc006b14t8gyghov8v/tiles/{z}/{x}/{y}?access_token=",
   Sys.getenv("MAPBOX_PUBLIC_TOKEN")
   )
 

--- a/renv.lock
+++ b/renv.lock
@@ -39,18 +39,18 @@
     },
     "KernSmooth": {
       "Package": "KernSmooth",
-      "Version": "2.23-24",
+      "Version": "2.23-22",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "stats"
       ],
-      "Hash": "9f33a1ee37bbe8919eb2ec4b9f2473a5"
+      "Hash": "2fecebc3047322fa5930f74fae5de70f"
     },
     "MASS": {
       "Package": "MASS",
-      "Version": "7.3-60.0.1",
+      "Version": "7.3-60",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -61,11 +61,11 @@
         "stats",
         "utils"
       ],
-      "Hash": "b765b28387acc8ec9e9c1530713cb19c"
+      "Hash": "a56a6365b3fa73293ea8d084be0d9bb0"
     },
     "Matrix": {
       "Package": "Matrix",
-      "Version": "1.6-5",
+      "Version": "1.6-1.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -78,7 +78,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "8c7115cd3a0e048bda2a7cd110549f7a"
+      "Hash": "1a00d4828f33a9d690806e98bd17150c"
     },
     "PKI": {
       "Package": "PKI",
@@ -113,18 +113,18 @@
     },
     "Rcpp": {
       "Package": "Rcpp",
-      "Version": "1.0.13-1",
+      "Version": "1.0.14",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "methods",
         "utils"
       ],
-      "Hash": "6b868847b365672d6c1677b1608da9ed"
+      "Hash": "e7bdd9ee90e96921ca8a0f1972d66682"
     },
     "XML": {
       "Package": "XML",
-      "Version": "3.99-0.17",
+      "Version": "3.99-0.18",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -132,7 +132,7 @@
         "methods",
         "utils"
       ],
-      "Hash": "bc2a8a1139d8d4bd9c46086708945124"
+      "Hash": "4a5eca1070ecfe97e68727ed4b9a89fa"
     },
     "abind": {
       "Package": "abind",
@@ -178,21 +178,22 @@
     },
     "bit64": {
       "Package": "bit64",
-      "Version": "4.5.2",
+      "Version": "4.6.0-1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "bit",
+        "graphics",
         "methods",
         "stats",
         "utils"
       ],
-      "Hash": "e84984bf5f12a18628d9a02322128dfd"
+      "Hash": "4f572fbc586294afff277db583b9060f"
     },
     "bslib": {
       "Package": "bslib",
-      "Version": "0.8.0",
+      "Version": "0.9.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -210,7 +211,7 @@
         "rlang",
         "sass"
       ],
-      "Hash": "b299c6741ca9746fb227debcb0f9fb6c"
+      "Hash": "70a6489cc254171fb9b4a7f130f44dca"
     },
     "cachem": {
       "Package": "cachem",
@@ -250,7 +251,7 @@
     },
     "classInt": {
       "Package": "classInt",
-      "Version": "0.4-10",
+      "Version": "0.4-11",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -262,7 +263,7 @@
         "graphics",
         "stats"
       ],
-      "Hash": "f5a40793b1ae463a7ffb3902a95bf864"
+      "Hash": "f2af70314a63d7f025ae668f08bd933a"
     },
     "cli": {
       "Package": "cli",
@@ -298,6 +299,24 @@
         "stats"
       ],
       "Hash": "d954cb1c57e8d8b756165d7ba18aa55a"
+    },
+    "cols4all": {
+      "Package": "cols4all",
+      "Version": "0.8",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "abind",
+        "colorspace",
+        "grDevices",
+        "methods",
+        "png",
+        "spacesXYZ",
+        "stats",
+        "stringdist"
+      ],
+      "Hash": "67d7dceaf6088eb0550bcb245c247c19"
     },
     "commonmark": {
       "Package": "commonmark",
@@ -343,13 +362,13 @@
     },
     "curl": {
       "Package": "curl",
-      "Version": "6.0.1",
+      "Version": "6.2.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "e8ba62486230951fcd2b881c5be23f96"
+      "Hash": "b580cbb010099fd990df6bfe44459e1a"
     },
     "data.table": {
       "Package": "data.table",
@@ -425,13 +444,13 @@
     },
     "evaluate": {
       "Package": "evaluate",
-      "Version": "1.0.1",
+      "Version": "1.0.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "3fd29944b231036ad67c3edb32e02201"
+      "Hash": "e9651417729bbe7472e32b5027370e79"
     },
     "fansi": {
       "Package": "fansi",
@@ -774,7 +793,7 @@
     },
     "lattice": {
       "Package": "lattice",
-      "Version": "0.22-6",
+      "Version": "0.21-9",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -785,7 +804,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "cc5ac1ba4c238c7ca9fa6a87ca11a7e2"
+      "Hash": "5558c61e0136e247252f5f952cdaad6a"
     },
     "lazyeval": {
       "Package": "lazyeval",
@@ -815,6 +834,36 @@
         "sf"
       ],
       "Hash": "6b43f986a9a0c1c1810b2deec71bfdf2"
+    },
+    "leafgl": {
+      "Package": "leafgl",
+      "Version": "0.2.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "geojsonsf",
+        "grDevices",
+        "htmltools",
+        "jsonify",
+        "leaflet",
+        "sf"
+      ],
+      "Hash": "7c6bdc5be0f1aa26f8f876649159058e"
+    },
+    "leaflegend": {
+      "Package": "leaflegend",
+      "Version": "1.2.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "base64enc",
+        "htmltools",
+        "htmlwidgets",
+        "leaflet",
+        "stats"
+      ],
+      "Hash": "b6ae2af92974c56c504b889287c6a9d7"
     },
     "leaflet": {
       "Package": "leaflet",
@@ -894,6 +943,17 @@
       ],
       "Hash": "b8552d117e1b808b09a832f589b79035"
     },
+    "logger": {
+      "Package": "logger",
+      "Version": "0.4.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "utils"
+      ],
+      "Hash": "f25d781d5bc7757e08cf38c741a5ad1c"
+    },
     "lubridate": {
       "Package": "lubridate",
       "Version": "1.9.4",
@@ -956,7 +1016,7 @@
     },
     "mgcv": {
       "Package": "mgcv",
-      "Version": "1.9-1",
+      "Version": "1.9-0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -969,7 +1029,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "110ee9d83b496279960e162ac97764ce"
+      "Hash": "086028ca0460d0c368028d3bda58f31b"
     },
     "mime": {
       "Package": "mime",
@@ -994,7 +1054,7 @@
     },
     "nlme": {
       "Package": "nlme",
-      "Version": "3.1-166",
+      "Version": "3.1-163",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1004,17 +1064,17 @@
         "stats",
         "utils"
       ],
-      "Hash": "ccbb8846be320b627e6aa2b4616a2ded"
+      "Hash": "8d1938040a05566f4f7a14af4feadd6b"
     },
     "openssl": {
       "Package": "openssl",
-      "Version": "2.3.0",
+      "Version": "2.3.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "askpass"
       ],
-      "Hash": "5bfe2927efa9f87766ca9605301ea48f"
+      "Hash": "37a7f0abce0349f5950ce49f38c7626b"
     },
     "packrat": {
       "Package": "packrat",
@@ -1030,7 +1090,7 @@
     },
     "pillar": {
       "Package": "pillar",
-      "Version": "1.10.0",
+      "Version": "1.10.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1042,7 +1102,7 @@
         "utils",
         "vctrs"
       ],
-      "Hash": "101ca350beea21261a15ba169d7a8513"
+      "Hash": "8b16b6097daef84cd3c40a6a7c5c9d86"
     },
     "pkgconfig": {
       "Package": "pkgconfig",
@@ -1182,7 +1242,7 @@
     },
     "raster": {
       "Package": "raster",
-      "Version": "3.6-30",
+      "Version": "3.6-31",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1192,7 +1252,7 @@
         "sp",
         "terra"
       ],
-      "Hash": "0e2829df8cb74a98179c886b023ffea8"
+      "Hash": "4b6f355fc2802fa27ab51bbb0d0c0469"
     },
     "readr": {
       "Package": "readr",
@@ -1241,24 +1301,24 @@
     },
     "renv": {
       "Package": "renv",
-      "Version": "1.0.11",
+      "Version": "1.1.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "utils"
       ],
-      "Hash": "47623f66b4e80b3b0587bc5d7b309888"
+      "Hash": "ac77c97ee12af521e554e9b015b80861"
     },
     "rlang": {
       "Package": "rlang",
-      "Version": "1.1.4",
+      "Version": "1.1.5",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "3eec01f8b1dee337674b2e34ab1f9bc1"
+      "Hash": "724dcc1490cd7071ee75ca2994a5446e"
     },
     "rmarkdown": {
       "Package": "rmarkdown",
@@ -1285,7 +1345,7 @@
     },
     "rsconnect": {
       "Package": "rsconnect",
-      "Version": "1.3.3",
+      "Version": "1.3.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1304,7 +1364,7 @@
         "tools",
         "yaml"
       ],
-      "Hash": "d466c98fdce812325feb4ad406c6ca4b"
+      "Hash": "315454d2f50d117ef58691d0bf50fe63"
     },
     "rstudioapi": {
       "Package": "rstudioapi",
@@ -1358,6 +1418,20 @@
         "viridisLite"
       ],
       "Hash": "c19df082ba346b0ffa6f833e92de34d1"
+    },
+    "servr": {
+      "Package": "servr",
+      "Version": "0.32",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "httpuv",
+        "jsonlite",
+        "mime",
+        "xfun"
+      ],
+      "Hash": "63e4ea2379e79cf18813dd0d8146d27c"
     },
     "sf": {
       "Package": "sf",
@@ -1515,6 +1589,17 @@
       ],
       "Hash": "75940133cca2e339afce15a586f85b11"
     },
+    "spacesXYZ": {
+      "Package": "spacesXYZ",
+      "Version": "1.4-0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "logger"
+      ],
+      "Hash": "e98b2ef7f9482fa4668fcd7a8ef4e867"
+    },
     "stars": {
       "Package": "stars",
       "Version": "0.6-7",
@@ -1531,6 +1616,17 @@
         "units"
       ],
       "Hash": "0df88c47fce8cda8cfe84ce05cc4c5a1"
+    },
+    "stringdist": {
+      "Package": "stringdist",
+      "Version": "0.9.15",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "parallel"
+      ],
+      "Hash": "749b8805a3026202a959edbf790425b0"
     },
     "stringi": {
       "Package": "stringi",
@@ -1571,7 +1667,7 @@
     },
     "terra": {
       "Package": "terra",
-      "Version": "1.8-5",
+      "Version": "1.8-10",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1579,7 +1675,7 @@
         "Rcpp",
         "methods"
       ],
-      "Hash": "6e3f2c53b58161327fe5787fe1a63d02"
+      "Hash": "03e35a7e2b044d284afe186c9b9f833d"
     },
     "tibble": {
       "Package": "tibble",
@@ -1662,36 +1758,38 @@
     },
     "tmap": {
       "Package": "tmap",
-      "Version": "3.3-4",
+      "Version": "4.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
-        "RColorBrewer",
-        "abind",
         "classInt",
+        "cli",
+        "cols4all",
+        "data.table",
         "grid",
         "htmltools",
         "htmlwidgets",
         "leafem",
+        "leafgl",
+        "leaflegend",
         "leaflet",
         "leafsync",
         "methods",
         "rlang",
+        "s2",
+        "servr",
         "sf",
         "stars",
         "stats",
         "tmaptools",
-        "units",
-        "utils",
-        "viridisLite",
-        "widgetframe"
+        "units"
       ],
-      "Hash": "c65363bc002492caf754352499ce2386"
+      "Hash": "984decf95d1e5d976214b581f0d4c2ce"
     },
     "tmaptools": {
       "Package": "tmaptools",
-      "Version": "3.1-1",
+      "Version": "3.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1709,7 +1807,7 @@
         "units",
         "viridisLite"
       ],
-      "Hash": "dfcb77371df343b663d6668d2d63ac35"
+      "Hash": "dd597445fa5aa8adbcae4d1d222a6f78"
     },
     "tzdb": {
       "Package": "tzdb",
@@ -1793,22 +1891,6 @@
       ],
       "Hash": "390f9315bc0025be03012054103d227c"
     },
-    "widgetframe": {
-      "Package": "widgetframe",
-      "Version": "0.3.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "htmltools",
-        "htmlwidgets",
-        "magrittr",
-        "purrr",
-        "tools",
-        "utils"
-      ],
-      "Hash": "0ee89e6cb58182d39b30a5b506e04808"
-    },
     "withr": {
       "Package": "withr",
       "Version": "3.0.2",
@@ -1833,7 +1915,7 @@
     },
     "xfun": {
       "Package": "xfun",
-      "Version": "0.49",
+      "Version": "0.50",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1842,7 +1924,7 @@
         "stats",
         "tools"
       ],
-      "Hash": "8687398773806cfff9401a2feca96298"
+      "Hash": "44ab88837d3f8dfc66a837299b887fa6"
     },
     "xtable": {
       "Package": "xtable",

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -2,7 +2,7 @@
 local({
 
   # the requested version of renv
-  version <- "1.0.11"
+  version <- "1.1.0"
   attr(version, "sha") <- NULL
 
   # the project directory


### PR DESCRIPTION
# Changes

The changes made in this PR are:

1. Update used packages with `renv::snapshot()`
1. Fix breaking changes caused by upgrading {tmap} package from v3 to v4

***

# Check

- [x] (If UI & data are updated) The UI & data includes Traditional Chinese translation, with translation terms wrapped in `i18n$t()` and terms added to `translation_zh.csv`
- [x] The GitHub Actions workflows pass.

***

## Note

The Mapbox tile for collision location in the hotzone tmap is yet to be fixed. It is suspected that currently it is not possible to directly add Mapbox map tiles using `tm_tiles()`
