### PR TITLE
Fix: Reduce maximum number of collisions allowed to be shown

### DIFF
--- a/inst/app/modules/district_dsb.R
+++ b/inst/app/modules/district_dsb.R
@@ -127,8 +127,6 @@ ddsb_filtered_hk_collisions = reactive({
     filter(!is.na(easting) & !is.na(northing)) %>%
     st_as_sf(coords = c("easting", "northing"), crs = 2326, remove = FALSE)
 
-  print(paste0("Number of records filtered in districh dashboard: ", nrow(hk_collisions_filtered)))
-
   hk_collisions_filtered
 
 })

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -185,29 +185,22 @@ filter_collision_data <-
 
       data_filtered <- filter(data_filtered, serial_no %in% accient_w_selected_veh_vct)
 
-      # Show at most 20,000 points on the map to ensure performance
-      if (nrow(data_filtered) > 20000) {
+      # Show at most 10,000 points on the map to ensure performance
+      if (nrow(data_filtered) > 10000) {
 
-        showNotification(
-          paste(
-            "
-            地圖不能顯示所有符合篩選條件的車禍。
-            此地圖只可以同時顯示最多 20,000 宗車禍，而現有篩選條件包含超過 20,000 宗車禍。
-            地圖只會顯示首 20,000 宗符合條件的車禍。
-            請更改篩選條件（如刪除地區，縮短日期範圍）以顯示所有符合篩選條件之車禍。
-            ",
-            "
-            The map cannot show all collisions matching the requirements.
-            The total number of collisions included in current filter settings exceeds the rendering capacity (20,000 points) of the map.
-            Only the first 20,000 records are shown on the map.
-            Change the filters (e.g. remove districts outside your area of interest, shortern the time frame) to show all filtered records.
-            "
-            , collapse = "<br/>"),
-          type = "error",
-          duration = NULL,
-        )
+        showModal(modalDialog(
+          title = "⚠️ 地圖無法顯示所有符合篩選條件的車禍 | The map cannot display all collisions  matching your filter criteria",
+          tags$ul(
+            tags$li("此地圖只可以同時顯示最多 10,000 宗車禍，而符合您目前篩選條件的車禍已超過此數量。"),
+            tags$li("請調整篩選條件（如縮小地區範圍／縮短日期範圍）以顯示所有符合篩選條件之車禍。"),
+            br(),
+            tags$li("The map can only display up to 10,000 collisions at once, and your current filters exceed this limit."),
+            tags$li("Adjust your filters (e.g., narrow the districts/shorten the date range) to view all qualifying collisions.")
+          ),
+          easyClose = TRUE
+        ))
 
-        return(data_filtered[1:20000,])
+        return(data_filtered[1:10000,])
       }
 
       data_filtered

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -150,7 +150,16 @@ output$main_map <- renderLeaflet({
     )
 })
 
-output$nrow_filtered <- reactive(format(nrow(filter_collision_data()), big.mark = ","))
+output$nrow_filtered <- reactive({
+
+  n_filtered = format(nrow(filter_collision_data()), big.mark = ",")
+
+  if(input$selected_language == "en"){
+    glue::glue("{n_filtered} collisions filtered")
+  } else {
+    glue::glue("已篩選 {n_filtered} 宗車禍")
+  }
+})
 
 # Filter the collision data according to users' input
 filter_collision_data <-

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -20,7 +20,7 @@ output$district_filter_ui = renderUI({
       lapply(DISTRICT_FULL_NAME, function(x) i18n$t(x))
     ),
     multiple = TRUE,
-    selected = DISTRICT_ABBR,
+    selected = c("CW", "WCH", "E", "S", "YTM", "SSP", "KC", "WTS", "KT"),
     options = list(placeholder = 'Select districts')
   ) %>%
     shinyhelper::helper(

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -176,9 +176,6 @@ filter_collision_data <-
       data_filtered = filter(hk_collisions_valid_sf,
                              year_month >= floor_date_to_month(input$month_range[1]) & year_month <= floor_date_to_month(input$month_range[2]))
 
-      message("Min date in filtered data: ", min(data_filtered$date_time))
-      message("Max date in filtered data: ", max(data_filtered$date_time))
-
       data_filtered = filter(data_filtered, collision_type_with_cycle %in% input$collision_type_filter)
 
       data_filtered = filter(data_filtered, severity %in% input$severity_filter)

--- a/inst/app/modules/main_map.R
+++ b/inst/app/modules/main_map.R
@@ -191,22 +191,22 @@ filter_collision_data <-
 
       data_filtered <- filter(data_filtered, serial_no %in% accient_w_selected_veh_vct)
 
-      # Show at most 10,000 points on the map to ensure performance
-      if (nrow(data_filtered) > 10000) {
+      # Show at most 5,000 points on the map to ensure performance
+      if (nrow(data_filtered) > 5000) {
 
         showModal(modalDialog(
-          title = "⚠️ 地圖無法顯示所有符合篩選條件的車禍 | The map cannot display all collisions  matching your filter criteria",
+          title = "⚠️ 地圖無法顯示所有符合篩選條件的車禍 | The map cannot display all collisions matching your filter criteria",
           tags$ul(
-            tags$li("此地圖只可以同時顯示最多 10,000 宗車禍，而符合您目前篩選條件的車禍已超過此數量。"),
+            tags$li("此地圖只可以同時顯示最多 5,000 宗車禍，而符合您目前篩選條件的車禍已超過此數量。"),
             tags$li("請調整篩選條件（如縮小地區範圍／縮短日期範圍）以顯示所有符合篩選條件之車禍。"),
             br(),
-            tags$li("The map can only display up to 10,000 collisions at once, and your current filters exceed this limit."),
+            tags$li("The map can only display up to 5,000 collisions at once, and your current filters exceed this limit."),
             tags$li("Adjust your filters (e.g., narrow the districts/shorten the date range) to view all qualifying collisions.")
           ),
           easyClose = TRUE
         ))
 
-        return(data_filtered[1:10000,])
+        return(data_filtered[1:5000,])
       }
 
       data_filtered

--- a/inst/app/translation/translation_zh.csv
+++ b/inst/app/translation/translation_zh.csv
@@ -16,7 +16,6 @@ Collision severity,車禍嚴重程度
 Collision type,車禍類別
 Collision,車禍
 Vehicle classes involved,涉事車輛類別
-Number of collisions in current filter settings: ,符合現有篩選組合之車禍總數：
 Central and Western,中西區
 Wan Chai,灣仔區
 Eastern,東區

--- a/inst/app/translation/translation_zh.csv
+++ b/inst/app/translation/translation_zh.csv
@@ -8,8 +8,8 @@ Data Download,數據下載
 Project Info,關於此專案
 User Survey,用戶問卷調查
 Filters,篩選分類
-Please use the data filters below to select the category of traffic collisions you would like to show on the map. The map will automatically update and show the collisions meeting the current filter settings.,請利用下列不同種類的數據過濾器選擇你想顯示的車禍。地圖會自動按你現時所選擇的條件更新及顯示符合現有組合之車禍。
-Zoom to matched collisions,縮放至合符現有篩選條件之車禍
+Use the filter tools below to set your criteria and focus on specific collisions. The map will automatically update to show matching collisions.,使用下方篩選工具選擇特定車禍。地圖會自動更新至符合條件的車禍。
+Zoom to matching collisions,縮放至符合條件的車禍
 District(s),地區
 Date range,日期範圍
 Collision severity,車禍嚴重程度
@@ -93,7 +93,7 @@ Yes,是
 No,否
 View this location in Google Street View,於 Google 街景顯示此車禍位置
 District Dashboard, 地區儀表版
-Select collisions to be summarised, 請選擇用以概述之車禍數據
+Choose collisions to analyse, 選取要分析的車禍
 Year Range, 年份範圍
 All Severities, 所有嚴重程度
 Killed or Seriously Injuries only, 只包含重傷或致命車禍

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -168,7 +168,7 @@ ui <- dashboardPage(
               h3(span(icon("filter")), " ", i18n$t("Filters")),
 
               p(
-                i18n$t("Please use the data filters below to select the category of traffic collisions you would like to show on the map. The map will automatically update and show the collisions meeting the current filter settings."),
+                i18n$t("Use the filter tools below to set your criteria and focus on specific collisions. The map will automatically update to show matching collisions."),
                 # add spacing to the first widget
                 style = "margin-bottom: 20px"
                 ),
@@ -178,7 +178,7 @@ ui <- dashboardPage(
                 style = "font-size:20px;text-align:center;margin-bottom:5px"),
 
               div(
-                actionButton("zoom_to_pts", label = i18n$t("Zoom to matched collisions"), icon = icon("search-plus")),
+                actionButton("zoom_to_pts", label = i18n$t("Zoom to matching collisions"), icon = icon("search-plus")),
                 style = "display: flex;justify-content: center;align-items: center;margin-bottom: 20px;"
                 ),
 
@@ -207,7 +207,7 @@ ui <- dashboardPage(
             width = 12,
             title = span(icon("tachometer-alt"), i18n$t("District Dashboard")),
 
-            h4(i18n$t("Select collisions to be summarised")),
+            h4(i18n$t("Choose collisions to analyse")),
 
             column(
               width = 4,

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -170,12 +170,16 @@ ui <- dashboardPage(
               p(
                 i18n$t("Please use the data filters below to select the category of traffic collisions you would like to show on the map. The map will automatically update and show the collisions meeting the current filter settings."),
                 # add spacing to the first widget
-                style = "margin-bottom: 10px"
+                style = "margin-bottom: 20px"
                 ),
+
+              p(
+                tags$b(textOutput("nrow_filtered", inline = TRUE)),
+                style = "font-size:20px;text-align:center;margin-bottom:5px"),
 
               div(
                 actionButton("zoom_to_pts", label = i18n$t("Zoom to matched collisions"), icon = icon("search-plus")),
-                style = "display: flex;justify-content: center;align-items: center;margin-bottom: 10px;"
+                style = "display: flex;justify-content: center;align-items: center;margin-bottom: 20px;"
                 ),
 
               uiOutput("district_filter_ui"),
@@ -186,12 +190,7 @@ ui <- dashboardPage(
 
               uiOutput("collision_type_filter_ui"),
 
-              uiOutput("vehicle_class_filter_ui"),
-
-              br(),
-
-              p(i18n$t("Number of collisions in current filter settings: "), textOutput("nrow_filtered", inline = TRUE),
-                style = "font-size: 20px;text-align:center;"),
+              uiOutput("vehicle_class_filter_ui")
             )
           )
         )


### PR DESCRIPTION
# Summary

This branch reduces the maximum number of collisions shown on the map to 5,000 to cope with the RAM limit of the shinyapps.io free tier.

# Changes

The changes made in this PR are:

1. Reduce the maximum number of collisions allowed to be shown on the map to 5,000 
1. Changes the default selected districts in district filter from all 18 districts to 9 core urban districts

***

# Check

- [x] (If UI & data are updated) The UI & data includes Traditional Chinese translation, with translation terms wrapped in `i18n$t()` and terms added to `translation_zh.csv`
- [x] The GitHub Actions workflows pass.


